### PR TITLE
feat: 태스크 상세 조회 및 목록 조회 구현, 태스크 생성 기능 수정

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/common/code/ErrorCode.java
+++ b/src/main/java/org/devlogtwo/devlog/common/code/ErrorCode.java
@@ -19,7 +19,10 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "잘못된 사용자명 또는 비밀번호입니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자가 존재하지 않습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자가 존재하지 않습니다."),
+
+    // --- Task Errors ---
+    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 태스크를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/devlogtwo/devlog/common/code/SuccessCode.java
+++ b/src/main/java/org/devlogtwo/devlog/common/code/SuccessCode.java
@@ -18,6 +18,8 @@ public enum SuccessCode {
 
     // --- Task Success ---
     TASK_CREATED(HttpStatus.CREATED, "Task가 생성되었습니다."),
+    GET_TASK_SUCCESS(HttpStatus.OK, "Task를 조회했습니다."),
+
 
     // --- Team Success ---
     TEAM_CREATE_SUCCESS(HttpStatus.CREATED, "팀이 성공적으로 생성되었습니다.");

--- a/src/main/java/org/devlogtwo/devlog/common/code/SuccessCode.java
+++ b/src/main/java/org/devlogtwo/devlog/common/code/SuccessCode.java
@@ -19,15 +19,13 @@ public enum SuccessCode {
     // --- Task Success ---
     TASK_CREATED(HttpStatus.CREATED, "Task가 생성되었습니다."),
     GET_TASK_SUCCESS(HttpStatus.OK, "Task를 조회했습니다."),
-
-
+    GET_TASKS_SUCCESS(HttpStatus.OK, "Task 목록을 조회했습니다."),
 
     //--- comment Success ---
     COMMENT_CREATED(HttpStatus.CREATED, "Comment가 생성되었습니다."),
 
     // --- Team Success ---
     TEAM_CREATE_SUCCESS(HttpStatus.CREATED, "팀이 성공적으로 생성되었습니다.");
-
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/devlogtwo/devlog/domain/task/controller/TaskController.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/controller/TaskController.java
@@ -1,20 +1,25 @@
 package org.devlogtwo.devlog.domain.task.controller;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.code.SuccessCode;
 import org.devlogtwo.devlog.common.dto.GlobalApiResponse;
+import org.devlogtwo.devlog.common.type.TaskStatus;
 import org.devlogtwo.devlog.common.util.ResponseHelper;
 import org.devlogtwo.devlog.domain.task.dto.request.TaskCreateRequest;
 import org.devlogtwo.devlog.domain.task.dto.response.TaskCreateResponse;
+import org.devlogtwo.devlog.domain.task.dto.response.TaskPageResponse;
 import org.devlogtwo.devlog.domain.task.dto.response.TaskResponse;
 import org.devlogtwo.devlog.domain.task.service.TaskService;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -39,5 +44,12 @@ public class TaskController {
         TaskResponse response = taskService.getTask(taskId);
 
         return ResponseHelper.success(SuccessCode.GET_TASK_SUCCESS, response);
+    }
+
+    @GetMapping
+    public ResponseEntity<GlobalApiResponse<TaskPageResponse>> getTaskList(@RequestParam(required = false) TaskStatus status, Pageable pageable) {
+
+        TaskPageResponse response = taskService.getTaskList(status, pageable);
+        return ResponseHelper.success(SuccessCode.GET_TASKS_SUCCESS, response);
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/task/controller/TaskController.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/controller/TaskController.java
@@ -47,7 +47,8 @@ public class TaskController {
     }
 
     @GetMapping
-    public ResponseEntity<GlobalApiResponse<TaskPageResponse>> getTaskList(@RequestParam(required = false) TaskStatus status, Pageable pageable) {
+    public ResponseEntity<GlobalApiResponse<TaskPageResponse>> getTaskList(
+            @RequestParam(required = false) TaskStatus status, Pageable pageable) {
 
         TaskPageResponse response = taskService.getTaskList(status, pageable);
         return ResponseHelper.success(SuccessCode.GET_TASKS_SUCCESS, response);

--- a/src/main/java/org/devlogtwo/devlog/domain/task/controller/TaskController.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/controller/TaskController.java
@@ -7,8 +7,11 @@ import org.devlogtwo.devlog.common.dto.GlobalApiResponse;
 import org.devlogtwo.devlog.common.util.ResponseHelper;
 import org.devlogtwo.devlog.domain.task.dto.request.TaskCreateRequest;
 import org.devlogtwo.devlog.domain.task.dto.response.TaskCreateResponse;
+import org.devlogtwo.devlog.domain.task.dto.response.TaskResponse;
 import org.devlogtwo.devlog.domain.task.service.TaskService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,5 +31,13 @@ public class TaskController {
         TaskCreateResponse response = taskService.createTask(request);
 
         return ResponseHelper.success(SuccessCode.TASK_CREATED, response);
+    }
+
+    @GetMapping("/{taskId}")
+    public ResponseEntity<GlobalApiResponse<TaskResponse>> getTask(@PathVariable Long taskId) {
+
+        TaskResponse response = taskService.getTask(taskId);
+
+        return ResponseHelper.success(SuccessCode.GET_TASK_SUCCESS, response);
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/task/dto/response/TaskPageResponse.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/dto/response/TaskPageResponse.java
@@ -1,0 +1,23 @@
+package org.devlogtwo.devlog.domain.task.dto.response;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record TaskPageResponse(
+        List<TaskResponse> content,
+        Long totalElements,
+        int totalPages,
+        int size,
+        int number
+) {
+
+    public static TaskPageResponse from(Page<TaskResponse> page) {
+        return new TaskPageResponse(
+                page.getContent(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getSize(),
+                page.getNumber()
+        );
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/domain/task/dto/response/TaskResponse.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/dto/response/TaskResponse.java
@@ -36,8 +36,10 @@ public record TaskResponse(
 
     public static TaskResponse from(Task task) {
         User assignee = task.getAssignee();
+
         return new TaskResponse(task.getId(), task.getTitle(), task.getDescription(), task.getDueDate(),
-                task.getPriority(), task.getStatus(), assignee.getId(), Assignee.from(assignee), task.getCreatedAt(),
+                task.getPriority(), task.getStatus(), assignee != null ? assignee.getId() : null,
+                Assignee.from(assignee), task.getCreatedAt(),
                 task.getUpdatedAt());
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/task/dto/response/TaskResponse.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/dto/response/TaskResponse.java
@@ -1,0 +1,43 @@
+package org.devlogtwo.devlog.domain.task.dto.response;
+
+import java.time.LocalDateTime;
+import org.devlogtwo.devlog.common.type.TaskPriority;
+import org.devlogtwo.devlog.common.type.TaskStatus;
+import org.devlogtwo.devlog.domain.task.entity.Task;
+import org.devlogtwo.devlog.domain.user.entity.User;
+
+public record TaskResponse(
+        Long id,
+        String title,
+        String description,
+        LocalDateTime dueDate,
+        TaskPriority priority,
+        TaskStatus status,
+        Long assigneeId,
+        Assignee assignee,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public record Assignee(
+            Long id,
+            String username,
+            String name,
+            String email
+    ) {
+        public static Assignee from(User user) {
+            if (user == null) {
+                return null;
+            }
+
+            return new Assignee(user.getId(), user.getUsername(), user.getName(), user.getEmail());
+        }
+    }
+
+    public static TaskResponse from(Task task) {
+        User assignee = task.getAssignee();
+        return new TaskResponse(task.getId(), task.getTitle(), task.getDescription(), task.getDueDate(),
+                task.getPriority(), task.getStatus(), assignee.getId(), Assignee.from(assignee), task.getCreatedAt(),
+                task.getUpdatedAt());
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/domain/task/repository/TaskRepository.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/repository/TaskRepository.java
@@ -1,7 +1,12 @@
 package org.devlogtwo.devlog.domain.task.repository;
 
+import org.devlogtwo.devlog.common.type.TaskStatus;
 import org.devlogtwo.devlog.domain.task.entity.Task;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    Page<Task> findByStatus(TaskStatus status, Pageable pageable);
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
@@ -53,12 +53,16 @@ public class TaskService implements TaskServiceApi {
     @Transactional(readOnly = true)
     public TaskPageResponse getTaskList(TaskStatus status, Pageable pageable) {
 
-        Page<Task> taskPage = taskRepository.findByStatus(status, pageable);
+        Page<Task> taskPage;
+
+        if (status == null) {
+            taskPage = taskRepository.findAll(pageable);
+        } else {
+            taskPage = taskRepository.findByStatus(status, pageable);
+        }
 
         Page<TaskResponse> responsePage = taskPage.map(TaskResponse::from);
 
         return TaskPageResponse.from(responsePage);
-
-
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
@@ -6,6 +6,7 @@ import org.devlogtwo.devlog.domain.task.dto.response.TaskCreateResponse;
 import org.devlogtwo.devlog.domain.task.entity.Task;
 import org.devlogtwo.devlog.domain.task.repository.TaskRepository;
 import org.devlogtwo.devlog.domain.user.entity.User;
+import org.devlogtwo.devlog.domain.user.service.UserServiceApi;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,12 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class TaskService implements TaskServiceApi {
 
     private final TaskRepository taskRepository;
+    private final UserServiceApi userServiceApi;
 
     @Transactional
     public TaskCreateResponse createTask(TaskCreateRequest request) {
 
-        // TODO: 담당자 ID 검증 로직 (User 도메인 구현 이후 구현할 예정)
-        User assignee = null;
+        // 담당자 ID 검증 로직
+        User assignee = userServiceApi.findUserById(request.assigneeId());
 
         Task task = Task.create(request.title(), request.description(), request.priority(), assignee,
                 request.dueDate());

--- a/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
@@ -1,8 +1,11 @@
 package org.devlogtwo.devlog.domain.task.service;
 
 import lombok.RequiredArgsConstructor;
+import org.devlogtwo.devlog.common.code.ErrorCode;
+import org.devlogtwo.devlog.common.exception.CustomBusinessException;
 import org.devlogtwo.devlog.domain.task.dto.request.TaskCreateRequest;
 import org.devlogtwo.devlog.domain.task.dto.response.TaskCreateResponse;
+import org.devlogtwo.devlog.domain.task.dto.response.TaskResponse;
 import org.devlogtwo.devlog.domain.task.entity.Task;
 import org.devlogtwo.devlog.domain.task.repository.TaskRepository;
 import org.devlogtwo.devlog.domain.user.entity.User;
@@ -29,5 +32,15 @@ public class TaskService implements TaskServiceApi {
         Task savedTask = taskRepository.save(task);
 
         return TaskCreateResponse.from(savedTask);
+    }
+
+    @Transactional(readOnly = true)
+    public TaskResponse getTask(Long taskId) {
+
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new CustomBusinessException(ErrorCode.TASK_NOT_FOUND));
+
+        return TaskResponse.from(task);
+
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
@@ -1,15 +1,20 @@
 package org.devlogtwo.devlog.domain.task.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.code.ErrorCode;
 import org.devlogtwo.devlog.common.exception.CustomBusinessException;
+import org.devlogtwo.devlog.common.type.TaskStatus;
 import org.devlogtwo.devlog.domain.task.dto.request.TaskCreateRequest;
 import org.devlogtwo.devlog.domain.task.dto.response.TaskCreateResponse;
+import org.devlogtwo.devlog.domain.task.dto.response.TaskPageResponse;
 import org.devlogtwo.devlog.domain.task.dto.response.TaskResponse;
 import org.devlogtwo.devlog.domain.task.entity.Task;
 import org.devlogtwo.devlog.domain.task.repository.TaskRepository;
 import org.devlogtwo.devlog.domain.user.entity.User;
 import org.devlogtwo.devlog.domain.user.service.UserServiceApi;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +39,7 @@ public class TaskService implements TaskServiceApi {
         return TaskCreateResponse.from(savedTask);
     }
 
+    // 태스크 상세 조회
     @Transactional(readOnly = true)
     public TaskResponse getTask(Long taskId) {
 
@@ -41,6 +47,18 @@ public class TaskService implements TaskServiceApi {
                 .orElseThrow(() -> new CustomBusinessException(ErrorCode.TASK_NOT_FOUND));
 
         return TaskResponse.from(task);
+    }
+
+    // 태스크 목록 조회
+    @Transactional(readOnly = true)
+    public TaskPageResponse getTaskList(TaskStatus status, Pageable pageable) {
+
+        Page<Task> taskPage = taskRepository.findByStatus(status, pageable);
+
+        Page<TaskResponse> responsePage = taskPage.map(TaskResponse::from);
+
+        return TaskPageResponse.from(responsePage);
+
 
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
> #23 

<br>

## ✨ 작업 내용
- [x] 태스크 생성 수정
> - UserServiceApi를 연동하여 담당자(assigneeId)의 유효성을 검증하는 로직을 추가했습니다.

- [x] 태스크 상세 조회 구현
> - GET /api/tasks/{taskId} 
> - TaskResponse DTO 생성

- [x] 태스크 목록 조회 구현
> - GET /api/task?status&page&size&search&assigneeId
> - status별 필터링과 page, size, sort

## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
