### PR TITLE
feat: SpringSecurity 를 이용한 @AuthenticationPrincipal 사용자 정보 접근 구현

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/common/config/SecurityConfig.java
+++ b/src/main/java/org/devlogtwo/devlog/common/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package org.devlogtwo.devlog.common.config;
 
+import lombok.RequiredArgsConstructor;
+import org.devlogtwo.devlog.common.security.JwtAuthFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,9 +10,13 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -38,7 +44,8 @@ public class SecurityConfig {
 //                        .anyRequest().authenticated()
         );
 
-        // TODO: JWT 인증 필터 추가
+        // JWT 인증 필터 추가
+        http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/org/devlogtwo/devlog/common/security/JwtAuthFilter.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/JwtAuthFilter.java
@@ -1,0 +1,97 @@
+package org.devlogtwo.devlog.common.security;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.devlogtwo.devlog.domain.user.entity.User;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtUserDetailsService jwtUserDetailsService;
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            // Header로부터 Token 추출
+            String authHeaderValue = getAuthHeaderValue(request);
+            String bearerToken = getToken(authHeaderValue);
+
+            // 토큰 존재 여부 확인
+            if (bearerToken == null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // 토큰 검증
+            Claims claims = jwtTokenProvider.validateToken(bearerToken);
+            String currentUsername = claims.getSubject();
+            log.info("[JwtAuthFilter] JWT Authenticated user: " + currentUsername);
+
+            // 사용자 정보 추출 및 인증 객체 생성
+            setAuthentication(currentUsername);
+        } catch (Exception e) {
+            handlerExceptionResolver.resolveException(request, response, null, e);
+            return;
+        }
+
+        // 필터 보내기
+        filterChain.doFilter(request, response);
+    }
+
+    private String getAuthHeaderValue(HttpServletRequest request) {
+        return request.getHeader(AUTHORIZATION_HEADER);
+    }
+
+    private String getToken(String authHeaderValue) {
+        if (StringUtils.hasText(authHeaderValue) && authHeaderValue.startsWith(BEARER_PREFIX)) {
+            return authHeaderValue.substring(BEARER_PREFIX.length());
+        }
+
+        return null;
+    }
+
+    private void setAuthentication(String username) {
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        // 1. 사용자 정보(UserDetails) 조회
+        UserDetails userDetails = jwtUserDetailsService.loadUserByUsername(username);
+
+        // 2. 비밀번호 접근 방지를 위해 별도의 JwtUserDetails가 아닌 UserPrincipal 객체 생성
+        User user = ((JwtUserDetails) userDetails).getUser();
+        UserPrincipal principal = UserPrincipal.from(user);
+
+        // 3. Authentication 객체 생성
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null,
+                userDetails.getAuthorities());
+
+        // 4. SecurityContext에 저장
+        context.setAuthentication(authentication);
+
+        // 5. SecurityContextHolder에 최종 저장
+        SecurityContextHolder.setContext(context);
+        log.info("[JwtAuthFilter] @AuthenticationPrincipal 생성 성공: " + principal.username());
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/common/security/JwtAuthFilter.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/JwtAuthFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             // 토큰 검증
             Claims claims = jwtTokenProvider.validateToken(bearerToken);
             String currentUsername = claims.getSubject();
-            log.info("[JwtAuthFilter] JWT Authenticated user: " + currentUsername);
+            log.debug("[JwtAuthFilter] JWT Authenticated user: " + currentUsername);
 
             // 사용자 정보 추출 및 인증 객체 생성
             setAuthentication(currentUsername);
@@ -92,6 +92,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         // 5. SecurityContextHolder에 최종 저장
         SecurityContextHolder.setContext(context);
-        log.info("[JwtAuthFilter] @AuthenticationPrincipal 생성 성공: " + principal.username());
+        log.debug("[JwtAuthFilter] @AuthenticationPrincipal 생성 성공: " + principal.username());
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/common/security/JwtTokenProvider.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/JwtTokenProvider.java
@@ -32,6 +32,7 @@ public class JwtTokenProvider {
     public String createToken(String username) {
 
         Claims claims = Jwts.claims()
+                .add("username", username)
                 .build();
 
         Instant now = Instant.now();

--- a/src/main/java/org/devlogtwo/devlog/common/security/JwtTokenProvider.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package org.devlogtwo.devlog.common.config;
+package org.devlogtwo.devlog.common.security;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -8,18 +8,16 @@ import jakarta.annotation.PostConstruct;
 import java.time.Instant;
 import java.util.Date;
 import javax.crypto.SecretKey;
-import org.devlogtwo.devlog.domain.user.entity.User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class JwtUtil {
+public class JwtTokenProvider {
 
-    // Token 식별자
-    private final static String BEARER_PREFIX = "Bearer ";
 
     @Value("${jwt.secret.key}")
     private String secretKeyString;
+
     @Value("${jwt.expiration}")
     private long tokenExpirationTime;
     private SecretKey secretKey;
@@ -31,24 +29,22 @@ public class JwtUtil {
     }
 
 
-    public String createToken(Long userId, User user) {
+    public String createToken(String username) {
 
         Claims claims = Jwts.claims()
-                .add("userId", userId)
-                .add("role", user.getRole().name())
                 .build();
 
         Instant now = Instant.now();
         return Jwts.builder()
                 .claims(claims)
-                .subject(user.getUsername())
+                .subject(username)
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(now.plusMillis(tokenExpirationTime)))
                 .signWith(secretKey)
                 .compact();
     }
 
-    public Claims parseToken(String token) {
+    public Claims validateToken(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)
                 .build()

--- a/src/main/java/org/devlogtwo/devlog/common/security/JwtUserDetails.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/JwtUserDetails.java
@@ -1,0 +1,37 @@
+package org.devlogtwo.devlog.common.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Builder;
+import org.devlogtwo.devlog.domain.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * AuthenticationManager로 로그인 과정을 전환하면 로그인 과정에서만 사용 예정
+ *
+ * @param user
+ */
+@Builder
+public record JwtUserDetails(User user) implements UserDetails {
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(user.getRole().getAuthority()));
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/common/security/JwtUserDetailsService.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/JwtUserDetailsService.java
@@ -1,0 +1,27 @@
+package org.devlogtwo.devlog.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.devlogtwo.devlog.domain.user.entity.User;
+import org.devlogtwo.devlog.domain.user.service.UserServiceApi;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JwtUserDetailsService implements UserDetailsService {
+
+    private final UserServiceApi userService;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userService.findUserByUsername(username);
+
+        return JwtUserDetails.builder()
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/common/security/UserPrincipal.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/UserPrincipal.java
@@ -1,0 +1,25 @@
+package org.devlogtwo.devlog.common.security;
+
+import org.devlogtwo.devlog.common.type.UserRole;
+import org.devlogtwo.devlog.domain.user.entity.User;
+
+/**
+ * 비밀번호를 제외한 User 정보만 담아서 사용하기 위한 클래스 @AuthenticationPrincipal로 접근
+ *
+ * @param id
+ * @param username
+ * @param role
+ */
+public record UserPrincipal(
+        Long id,
+        String username,
+        UserRole role
+) {
+    public static UserPrincipal from(User user) {
+        return new UserPrincipal(
+                user.getId(),
+                user.getUsername(),
+                user.getRole()
+        );
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/domain/auth/service/AuthService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/auth/service/AuthService.java
@@ -2,8 +2,8 @@ package org.devlogtwo.devlog.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.code.ErrorCode;
-import org.devlogtwo.devlog.common.config.JwtUtil;
 import org.devlogtwo.devlog.common.exception.CustomBusinessException;
+import org.devlogtwo.devlog.common.security.JwtTokenProvider;
 import org.devlogtwo.devlog.common.type.UserRole;
 import org.devlogtwo.devlog.domain.auth.dto.request.AuthLoginRequest;
 import org.devlogtwo.devlog.domain.auth.dto.request.AuthRegisterRequest;
@@ -22,7 +22,7 @@ public class AuthService {
     private final UserService userService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final JwtUtil jwtUtil;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public AuthRegisterResponse signUp(AuthRegisterRequest authRegisterRequest) {
 
@@ -64,7 +64,7 @@ public class AuthService {
         }
 
         // token 생성
-        String token = jwtUtil.createToken(user.getId(), user);
+        String token = jwtTokenProvider.createToken(user.getUsername());
         return AuthLoginResponse.from(token);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
> close #32 

<br>

## ✨ 작업 내용
- **인증 흐름 구현**
    - SecurityFilterChain 직접 구성
    - JWT 토큰 검증 → Authentication 객체 생성 → SecurityContextHolder 저장
    - 컨트롤러에서 `@AuthenticationPrincipal` 로 사용자 정보 접근 가능
<br>

## 💬 리뷰 중점사항
- JwtTokenProvider의 createToken 메서드의 인자로 username 넘김 
-> Spring Security에서 제공하는 인터페이스 UserDetailService를 implements하여 JwtUserDetailsService 구현
-> JwtUserDetailsService에서 구현이 강제되는 loadUserByUsername() 에서 사용
-  userDetails를 implements한 JwtUserDetails는 getPassword() 를 구현 강제함
-> 차후 로그인 로직을 직접 구현에서 AuthenticationManager를 이용한 로그인으로 개선시에만 사용?
-  @AuthenticationPrincipal 에서는 비밀번호를 제외하고, userId, username, userRole만 제공하는 별도의 UserPrincipal 클래스 사용 

<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
