### PR TITLE
feat: Task 삭제 시 연관된 Comment 일괄 삭제 구현

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/domain/task/entity/Task.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/entity/Task.java
@@ -1,5 +1,6 @@
 package org.devlogtwo.devlog.domain.task.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,7 +11,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +22,7 @@ import lombok.NoArgsConstructor;
 import org.devlogtwo.devlog.common.entity.BaseTimeEntity;
 import org.devlogtwo.devlog.common.type.TaskPriority;
 import org.devlogtwo.devlog.common.type.TaskStatus;
+import org.devlogtwo.devlog.domain.comment.entity.Comment;
 import org.devlogtwo.devlog.domain.task.dto.request.TaskUpdateRequest;
 import org.devlogtwo.devlog.domain.user.entity.User;
 import org.hibernate.annotations.SQLDelete;
@@ -54,6 +59,9 @@ public class Task extends BaseTimeEntity {
     private LocalDateTime dueDate;
 
     private LocalDateTime deletedAt;
+
+    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 
     @Builder
     private Task(String title, String description, TaskPriority priority, User assignee, LocalDateTime dueDate) {


### PR DESCRIPTION
## 📌 관련 이슈
> close #65 

<br>

## ✨ 작업 내용
- [x] Task와 Comment의 연관관계 개선 (단방향 → 양방향)
> - Task 엔티티에 Comment 리스트와 `@OneToMany` 어노테이션를 추가해서 Task가 Comment들을 알 수 있도록 양방향 관계로 설정
> - `@OneToMany` 어노테이션에 `cascade = CascadeType.ALL` 및 `orphanRemoval = true` 옵션을 추가

## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
