### PR TITLE
feat: 비밀번호 확인 필드 제거 및 관련 검증 로직 제거

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/common/security/JwtAuthFilter.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/JwtAuthFilter.java
@@ -38,16 +38,19 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             String authHeaderValue = getAuthHeaderValue(request);
             String bearerToken = getToken(authHeaderValue);
 
+            log.info(bearerToken);
             // 토큰 존재 여부 확인
             if (bearerToken == null) {
                 filterChain.doFilter(request, response);
+                log.info("[JwtAuthFilter] 토큰이 존재하지 않습니다.");
                 return;
             }
 
+            log.info("[JwtAuthFilter] 토큰이 존재합니다.");
             // 토큰 검증
             Claims claims = jwtTokenProvider.validateToken(bearerToken);
             String currentUsername = claims.getSubject();
-            log.debug("[JwtAuthFilter] JWT Authenticated user: " + currentUsername);
+            log.info("[JwtAuthFilter] JWT Authenticated user: " + currentUsername);
 
             // 사용자 정보 추출 및 인증 객체 생성
             setAuthentication(currentUsername);

--- a/src/main/java/org/devlogtwo/devlog/domain/auth/dto/request/AuthRegisterRequest.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/auth/dto/request/AuthRegisterRequest.java
@@ -20,9 +20,6 @@ public record AuthRegisterRequest(
         @Password
         String password,
 
-        @Password
-        String passwordConfirm,
-
         @NotBlank(message = "이름은 필수 입력값입니다.")
         @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하로 입력해주세요.")
         String name

--- a/src/main/java/org/devlogtwo/devlog/domain/auth/service/AuthService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/auth/service/AuthService.java
@@ -38,15 +38,7 @@ public class AuthService {
             throw new CustomBusinessException(ErrorCode.DUPLICATE_EMAIL);
         }
 
-        // 비밀번호, 비밀번호 확인 일치 여부 검증
-        String password = authRegisterRequest.password();
-        String passwordConfirm = authRegisterRequest.passwordConfirm();
-
-        if (!password.equals(passwordConfirm)) {
-            throw new CustomBusinessException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
-        }
-
-        String encodedPassword = passwordEncoder.encode(password);
+        String encodedPassword = passwordEncoder.encode(authRegisterRequest.password());
         User newUser = User.signUp(authRegisterRequest.username(), authRegisterRequest.name(),
                 authRegisterRequest.email(), encodedPassword, UserRole.USER);
 


### PR DESCRIPTION
## 📌 관련 이슈
> close #76 

<br>

## ✨ 작업 내용
클라이언트에서는 RequestBody에 passwordConfirm 필드를 보내지 않고 있는데,
서버에서는 passwordConfirm 필드를 찾고 있습니다.
따라서, Request DTO에서 passwordConfirm을 제거했습니다.
그 뒤, passwordConfirm을 사용하는 로직 역시 제거했습니다.
<br>

## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
