### PR TITLE
fix: 프로필 조회 API 응답에 name 필드 추가하여 수정

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/domain/user/dto/response/UserDetailsResponse.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/user/dto/response/UserDetailsResponse.java
@@ -8,6 +8,7 @@ public record UserDetailsResponse(
         Long id,
         String username,
         String email,
+        String name,
         UserRole role,
         LocalDateTime createdAt
 ) {
@@ -16,6 +17,7 @@ public record UserDetailsResponse(
                 user.getId(),
                 user.getUsername(),
                 user.getEmail(),
+                user.getName(),
                 user.getRole(),
                 user.getCreatedAt()
         );


### PR DESCRIPTION
## 📌 관련 이슈
> close #80 

<br>

## ✨ 작업 내용
내 프로필 조회 API에서 name을 반환하지 않고 있습니다.
따라서, 화면에서 이름을 보여주지 못하고 있습니다.
body로 반환하는 dto에 name 필드를 추가했습니다.
<br>

## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
