### PR TITLE
feat: Task 상태 순차 변경 규칙 구현

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/common/code/ErrorCode.java
+++ b/src/main/java/org/devlogtwo/devlog/common/code/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     TEAM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 팀명입니다"),
 
     // --- Task Errors ---
+    INVALID_TASK_STATUS_CHANGE(HttpStatus.BAD_REQUEST, "상태는 TODO -> IN_PROGRESS -> DONE 순으로만 변경 가능합니다."),
     TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 태스크를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
@@ -80,6 +80,11 @@ public class TaskService implements TaskServiceApi {
         TaskStatus currentStatus = task.getStatus();
         TaskStatus newStatus = request.status();
 
+        // 상태 변화 없을 경우 바로 반환
+        if (currentStatus == newStatus) {
+            return TaskResponse.from(task);
+        }
+
         boolean statusChangedCheck = false;
 
         if (currentStatus == TaskStatus.TODO && newStatus == TaskStatus.IN_PROGRESS) {

--- a/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
@@ -72,6 +72,22 @@ public class TaskService implements TaskServiceApi {
 
         Task task = findTaskById(taskId);
 
+        // 상태 순차 변경로직
+        TaskStatus currentStatus = task.getStatus();
+        TaskStatus newStatus = request.status();
+
+        boolean statusChangedCheck = false;
+
+        if (currentStatus == TaskStatus.TODO && newStatus == TaskStatus.IN_PROGRESS) {
+            statusChangedCheck = true;
+        } else if (currentStatus == TaskStatus.IN_PROGRESS && newStatus == TaskStatus.DONE) {
+            statusChangedCheck = true;
+        }
+
+        if (!statusChangedCheck) {
+            throw new CustomBusinessException(ErrorCode.INVALID_TASK_STATUS_CHANGE);
+        }
+
         task.updateStatus(request.status());
 
         return TaskResponse.from(task);


### PR DESCRIPTION
## 📌 관련 이슈
> close #98 

<br>

## ✨ 작업 내용
Task 상태가 변경될 때 TODO → IN_PROGRESS → DONE 순서로만 변경이 가능하도록 로직 구현
그 외의 DONE → IN_PROGRESS 또는 IN_PROGRESS → TODO 의 역순서 변경은 허용하지 않음.

> - TaskService 로직 추가
> - ErrorCode 추가 (예외 처리 구현)

## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
