### PR TITLE
feat: 활동 로그 조회 기능 구현

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/common/code/SuccessCode.java
+++ b/src/main/java/org/devlogtwo/devlog/common/code/SuccessCode.java
@@ -10,6 +10,9 @@ public enum SuccessCode {
 
     // --- Common Success ---
 
+    // --- Activity Log Success --
+    ACTIVITY_LOG_SUCCESS(HttpStatus.OK, "활동 로그를 조회했습니다."),
+    
     // --- User Success ---
     SIGNUP_SUCCESS(HttpStatus.OK, "회원가입이 완료되었습니다."),
     LOGIN_SUCCESS(HttpStatus.OK, "로그인이 완료되었습니다."),

--- a/src/main/java/org/devlogtwo/devlog/common/dto/PageResponse.java
+++ b/src/main/java/org/devlogtwo/devlog/common/dto/PageResponse.java
@@ -1,0 +1,24 @@
+package org.devlogtwo.devlog.common.dto;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+
+public record PageResponse<T>(
+        List<T> content,
+        long totalElements,
+        int totalPages,
+        int size,
+        int number
+) {
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getSize(),
+                page.getNumber()
+        );
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/common/type/ActivityType.java
+++ b/src/main/java/org/devlogtwo/devlog/common/type/ActivityType.java
@@ -6,17 +6,16 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ActivityType {
-    // 요구사항엔 있으나 명세서에는 없음
-//    USER_LOGIN("사용자 로그인"),
-//    USER_LOGOUT("사용자 로그아웃"),
 
-    TASK_CREATE("작업 생성"),
-    TASK_UPDATE("작업 수정"),
-    TASK_DELETE("작업 삭제"),
-    TASK_STATUS_CHANGE("작업 상태 변경"),
-    COMMENT_CREATE("댓글 작성"),
-    COMMENT_UPDATE("댓글 수정"),
-    COMMENT_DELETE("댓글 삭제");
+    USER_LOGIN("사용자 로그인"),
+    USER_LOGOUT("사용자 로그아웃"),
+    TASK_CREATED("작업 생성"),
+    TASK_UPDATED("작업 수정"),
+    TASK_DELETED("작업 삭제"),
+    TASK_STATUS_CHANGED("작업 상태 변경"),
+    COMMENT_CREATED("댓글 작성"),
+    COMMENT_UPDATED("댓글 수정"),
+    COMMENT_DELETED("댓글 삭제");
 
     private final String description;
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/aop/ActivityLogAspect.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/aop/ActivityLogAspect.java
@@ -80,7 +80,7 @@ public class ActivityLogAspect {
 
     private String getBeforeState(ActivityType type, ProceedingJoinPoint joinPoint) {
 
-        if (type != ActivityType.TASK_STATUS_CHANGE) {
+        if (type != ActivityType.TASK_STATUS_CHANGED) {
             return null;
         }
 
@@ -98,11 +98,11 @@ public class ActivityLogAspect {
 
         if (result instanceof TaskResponse task) {
             switch (type) {
-                case TASK_CREATE:
+                case TASK_CREATED:
                     return String.format("새로운 작업 '%s'을 생성했습니다.", task.title());
-                case TASK_UPDATE:
+                case TASK_UPDATED:
                     return "작업 정보를 수정했습니다.";
-                case TASK_STATUS_CHANGE:
+                case TASK_STATUS_CHANGED:
                     if (beforeState != null) {
                         return String.format("작업 상태를 '%s'에서 '%s'로 변경했습니다.", beforeState,
                                 task.status());
@@ -111,16 +111,16 @@ public class ActivityLogAspect {
             }
         } else if (result instanceof CommentResponse comment) {
             switch (type) {
-                case COMMENT_CREATE:
+                case COMMENT_CREATED:
                     return "작업에 댓글을 작성했습니다.";
-                case COMMENT_UPDATE:
+                case COMMENT_UPDATED:
                     return "댓글을 수정했습니다.";
             }
         } else {
             switch (type) {
-                case TASK_DELETE:
+                case TASK_DELETED:
                     return "작업을 삭제했습니다.";
-                case COMMENT_DELETE:
+                case COMMENT_DELETED:
                     return "댓글을 삭제했습니다.";
             }
         }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/controller/ActivityLogController.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/controller/ActivityLogController.java
@@ -10,6 +10,7 @@ import org.devlogtwo.devlog.common.util.ResponseHelper;
 import org.devlogtwo.devlog.domain.actlog.dto.response.ActivityLogResponse;
 import org.devlogtwo.devlog.domain.actlog.service.ActivityLogService;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +31,7 @@ public class ActivityLogController {
             @RequestParam(required = false) Long taskId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
-            @PageableDefault(size = 10, page = 0)
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable) {
 
         PageResponse<ActivityLogResponse> logPage = activityLogService.getActivityLogs(type, userId, taskId,

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/controller/ActivityLogController.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/controller/ActivityLogController.java
@@ -4,11 +4,11 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.code.SuccessCode;
 import org.devlogtwo.devlog.common.dto.GlobalApiResponse;
+import org.devlogtwo.devlog.common.dto.PageResponse;
 import org.devlogtwo.devlog.common.type.ActivityType;
 import org.devlogtwo.devlog.common.util.ResponseHelper;
 import org.devlogtwo.devlog.domain.actlog.dto.response.ActivityLogResponse;
 import org.devlogtwo.devlog.domain.actlog.service.ActivityLogService;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -24,7 +24,7 @@ public class ActivityLogController {
     private final ActivityLogService activityLogService;
 
     @GetMapping("/api/activities")
-    public ResponseEntity<GlobalApiResponse<Page<ActivityLogResponse>>> getActivities(
+    public ResponseEntity<GlobalApiResponse<PageResponse<ActivityLogResponse>>> getActivities(
             @RequestParam(required = false) ActivityType type,
             @RequestParam(required = false) Long userId,
             @RequestParam(required = false) Long taskId,
@@ -33,7 +33,7 @@ public class ActivityLogController {
             @PageableDefault(size = 10, page = 0)
             Pageable pageable) {
 
-        Page<ActivityLogResponse> logPage = activityLogService.getActivityLogs(type, userId, taskId,
+        PageResponse<ActivityLogResponse> logPage = activityLogService.getActivityLogs(type, userId, taskId,
                 startDate, endDate, pageable);
         return ResponseHelper.success(SuccessCode.ACTIVITY_LOG_SUCCESS, logPage);
     }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/controller/ActivityLogController.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/controller/ActivityLogController.java
@@ -1,0 +1,40 @@
+package org.devlogtwo.devlog.domain.actlog.controller;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.devlogtwo.devlog.common.code.SuccessCode;
+import org.devlogtwo.devlog.common.dto.GlobalApiResponse;
+import org.devlogtwo.devlog.common.type.ActivityType;
+import org.devlogtwo.devlog.common.util.ResponseHelper;
+import org.devlogtwo.devlog.domain.actlog.dto.response.ActivityLogResponse;
+import org.devlogtwo.devlog.domain.actlog.service.ActivityLogService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ActivityLogController {
+
+    private final ActivityLogService activityLogService;
+
+    @GetMapping("/api/activities")
+    public ResponseEntity<GlobalApiResponse<Page<ActivityLogResponse>>> getActivities(
+            @RequestParam(required = false) ActivityType type,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) Long taskId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @PageableDefault(size = 10, page = 0)
+            Pageable pageable) {
+
+        Page<ActivityLogResponse> logPage = activityLogService.getActivityLogs(type, userId, taskId,
+                startDate, endDate, pageable);
+        return ResponseHelper.success(SuccessCode.ACTIVITY_LOG_SUCCESS, logPage);
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/dto/response/ActivityLogResponse.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/dto/response/ActivityLogResponse.java
@@ -1,0 +1,28 @@
+package org.devlogtwo.devlog.domain.actlog.dto.response;
+
+import java.time.LocalDateTime;
+import org.devlogtwo.devlog.common.type.ActivityType;
+import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
+import org.devlogtwo.devlog.domain.user.dto.response.UserDetailsResponse;
+
+public record ActivityLogResponse(
+        Long id,
+        ActivityType type,
+        Long userId,
+        UserDetailsResponse user,
+        Long taskId,
+        LocalDateTime timestamp,
+        String description
+) {
+    public static ActivityLogResponse from(ActivityLog log) {
+        return new ActivityLogResponse(
+                log.getId(),
+                log.getType(),
+                log.getUser().getId(),
+                UserDetailsResponse.from(log.getUser()),
+                log.getTaskId(),
+                log.getCreatedAt(),
+                log.getDescription()
+        );
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/entity/ActivityLog.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/entity/ActivityLog.java
@@ -34,19 +34,19 @@ public class ActivityLog {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @NotNull
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @NotNull
+    @Column(nullable = false, length = 50)
     private ActivityType type;
 
-    @NotNull
+    @Column(nullable = false)
     private Long taskId;
 
     private Long commentId;
 
     @NotNull
+    @Column(nullable = false)
     private String description;
 
     @CreatedDate

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepository.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepository.java
@@ -2,6 +2,7 @@ package org.devlogtwo.devlog.domain.actlog.repository;
 
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long> {
+public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long>, JpaSpecificationExecutor<ActivityLog> {
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
@@ -1,11 +1,18 @@
 package org.devlogtwo.devlog.domain.actlog.service;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.type.ActivityType;
+import org.devlogtwo.devlog.domain.actlog.dto.response.ActivityLogResponse;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.devlogtwo.devlog.domain.actlog.repository.ActivityLogRepository;
+import org.devlogtwo.devlog.domain.actlog.specs.ActivityLogSpecs;
 import org.devlogtwo.devlog.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,11 +20,35 @@ public class ActivityLogService {
 
     private final ActivityLogRepository activityLogRepository;
 
+    @Transactional
     public void saveLog(User currentUser, ActivityType type, Long taskId, Long commentId, String description) {
 
         ActivityLog newActivityLog = ActivityLog.create(currentUser, type, taskId, commentId, description);
         activityLogRepository.save(newActivityLog);
     }
 
-    // TODO: 조회 요청시 별도의 메서드를 통해 반환
+    @Transactional(readOnly = true)
+    public Page<ActivityLogResponse> getActivityLogs(ActivityType type, Long userId, Long taskId,
+                                                     LocalDate startDate, LocalDate endDate,
+                                                     Pageable pageable) {
+
+        Specification<ActivityLog> spec = Specification.unrestricted();
+
+        if (type != null) {
+            spec = spec.and(ActivityLogSpecs.withType(type));
+        }
+
+        if (userId != null) {
+            spec = spec.and(ActivityLogSpecs.withUserId(userId));
+        }
+        if (taskId != null) {
+            spec = spec.and(ActivityLogSpecs.withTaskId(taskId));
+        }
+        if (startDate != null && endDate != null) {
+            spec = spec.and(ActivityLogSpecs.withDateBetween(startDate, endDate));
+        }
+
+        return activityLogRepository.findAll(spec, pageable)
+                .map(ActivityLogResponse::from);
+    }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
@@ -2,6 +2,7 @@ package org.devlogtwo.devlog.domain.actlog.service;
 
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.devlogtwo.devlog.common.dto.PageResponse;
 import org.devlogtwo.devlog.common.type.ActivityType;
 import org.devlogtwo.devlog.domain.actlog.dto.response.ActivityLogResponse;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
@@ -28,27 +29,16 @@ public class ActivityLogService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ActivityLogResponse> getActivityLogs(ActivityType type, Long userId, Long taskId,
-                                                     LocalDate startDate, LocalDate endDate,
-                                                     Pageable pageable) {
+    public PageResponse<ActivityLogResponse> getActivityLogs(ActivityType type, Long userId, Long taskId,
+                                                             LocalDate startDate, LocalDate endDate,
+                                                             Pageable pageable) {
 
-        Specification<ActivityLog> spec = Specification.unrestricted();
+        Specification<ActivityLog> spec = ActivityLogSpecs
+                .buildSpec(type, userId, taskId, startDate, endDate);
 
-        if (type != null) {
-            spec = spec.and(ActivityLogSpecs.withType(type));
-        }
-
-        if (userId != null) {
-            spec = spec.and(ActivityLogSpecs.withUserId(userId));
-        }
-        if (taskId != null) {
-            spec = spec.and(ActivityLogSpecs.withTaskId(taskId));
-        }
-        if (startDate != null && endDate != null) {
-            spec = spec.and(ActivityLogSpecs.withDateBetween(startDate, endDate));
-        }
-
-        return activityLogRepository.findAll(spec, pageable)
+        Page<ActivityLogResponse> pages = activityLogRepository.findAll(spec, pageable)
                 .map(ActivityLogResponse::from);
+
+        return PageResponse.from(pages);
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/specs/ActivityLogSpecs.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/specs/ActivityLogSpecs.java
@@ -1,0 +1,30 @@
+package org.devlogtwo.devlog.domain.actlog.specs;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.devlogtwo.devlog.common.type.ActivityType;
+import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
+import org.springframework.data.jpa.domain.Specification;
+
+public class ActivityLogSpecs {
+
+    public static Specification<ActivityLog> withType(ActivityType type) {
+        return (root, query, builder) -> builder.equal(root.get("type"), type);
+    }
+
+    public static Specification<ActivityLog> withUserId(Long userId) {
+        return (root, query, builder) -> builder.equal(root.get("user").get("id"), userId);
+    }
+
+    public static Specification<ActivityLog> withTaskId(Long taskId) {
+        return (root, query, builder) -> builder.equal(root.get("taskId"), taskId);
+    }
+
+    public static Specification<ActivityLog> withDateBetween(LocalDate startDate, LocalDate endDate) {
+        return (root, query, builder) -> builder.between(
+                root.get("createdAt"),
+                startDate.atStartOfDay(),
+                endDate.atTime(LocalTime.MAX)
+        );
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/specs/ActivityLogSpecs.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/specs/ActivityLogSpecs.java
@@ -8,23 +8,56 @@ import org.springframework.data.jpa.domain.Specification;
 
 public class ActivityLogSpecs {
 
+    public static Specification<ActivityLog> buildSpec(
+            ActivityType type, Long userId, Long taskId, LocalDate startDate, LocalDate endDate) {
+
+        Specification<ActivityLog> spec = orderByLatest();
+
+        if (type != null) {
+            spec = spec.and(withType(type));
+        }
+        if (userId != null) {
+            spec = spec.and(withUserId(userId));
+        }
+        if (taskId != null) {
+            spec = spec.and(withTaskId(taskId));
+        }
+        if (startDate != null && endDate != null) {
+            spec = spec.and(withDateBetween(startDate, endDate));
+        }
+
+        return spec;
+    }
+
     public static Specification<ActivityLog> withType(ActivityType type) {
-        return (root, query, builder) -> builder.equal(root.get("type"), type);
+        return (root, query, builder) ->
+                builder.equal(root.get("type"), type);
     }
 
     public static Specification<ActivityLog> withUserId(Long userId) {
-        return (root, query, builder) -> builder.equal(root.get("user").get("id"), userId);
+        return (root, query, builder) ->
+                builder.equal(root.get("user").get("id"), userId);
     }
 
     public static Specification<ActivityLog> withTaskId(Long taskId) {
-        return (root, query, builder) -> builder.equal(root.get("taskId"), taskId);
+        return (root, query, builder) ->
+                builder.equal(root.get("taskId"), taskId);
     }
 
     public static Specification<ActivityLog> withDateBetween(LocalDate startDate, LocalDate endDate) {
-        return (root, query, builder) -> builder.between(
-                root.get("createdAt"),
-                startDate.atStartOfDay(),
-                endDate.atTime(LocalTime.MAX)
-        );
+        return (root, query, builder) ->
+                builder.between(
+                        root.get("createdAt"),
+                        startDate.atStartOfDay(),
+                        endDate.atTime(LocalTime.MAX)
+                );
+    }
+
+    private static Specification<ActivityLog> orderByLatest() {
+        return (root, query, builder) -> {
+            // CriteriaQuery 객체에 직접 ORDER BY 추가
+            query.orderBy(builder.desc(root.get("createdAt")));
+            return builder.conjunction();
+        };
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/specs/ActivityLogSpecs.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/specs/ActivityLogSpecs.java
@@ -11,7 +11,7 @@ public class ActivityLogSpecs {
     public static Specification<ActivityLog> buildSpec(
             ActivityType type, Long userId, Long taskId, LocalDate startDate, LocalDate endDate) {
 
-        Specification<ActivityLog> spec = orderByLatest();
+        Specification<ActivityLog> spec = Specification.unrestricted();
 
         if (type != null) {
             spec = spec.and(withType(type));
@@ -22,8 +22,12 @@ public class ActivityLogSpecs {
         if (taskId != null) {
             spec = spec.and(withTaskId(taskId));
         }
-        if (startDate != null && endDate != null) {
-            spec = spec.and(withDateBetween(startDate, endDate));
+        if (startDate != null) {
+            spec = spec.and(withStartDate(startDate));
+        }
+
+        if (endDate != null) {
+            spec = spec.and(withEndDate(endDate));
         }
 
         return spec;
@@ -44,20 +48,19 @@ public class ActivityLogSpecs {
                 builder.equal(root.get("taskId"), taskId);
     }
 
-    public static Specification<ActivityLog> withDateBetween(LocalDate startDate, LocalDate endDate) {
+    private static Specification<ActivityLog> withStartDate(LocalDate startDate) {
         return (root, query, builder) ->
-                builder.between(
+                builder.greaterThanOrEqualTo(
                         root.get("createdAt"),
-                        startDate.atStartOfDay(),
-                        endDate.atTime(LocalTime.MAX)
+                        startDate.atStartOfDay()
                 );
     }
 
-    private static Specification<ActivityLog> orderByLatest() {
-        return (root, query, builder) -> {
-            // CriteriaQuery 객체에 직접 ORDER BY 추가
-            query.orderBy(builder.desc(root.get("createdAt")));
-            return builder.conjunction();
-        };
+    private static Specification<ActivityLog> withEndDate(LocalDate endDate) {
+        return (root, query, builder) ->
+                builder.lessThanOrEqualTo(
+                        root.get("createdAt"),
+                        endDate.atTime(LocalTime.MAX)
+                );
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/comment/service/CommentService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/comment/service/CommentService.java
@@ -34,7 +34,7 @@ public class CommentService implements CommentServiceApi {
     private final TaskServiceApi taskService;
 
 
-    @ActivityLogger(type = ActivityType.COMMENT_CREATE)
+    @ActivityLogger(type = ActivityType.COMMENT_CREATED)
     @Transactional
     public CommentResponse createComment(CommentCreateRequest request, Long taskId, Long userId) {
 
@@ -99,7 +99,7 @@ public class CommentService implements CommentServiceApi {
     }
 
 
-    @ActivityLogger(type = ActivityType.COMMENT_DELETE)
+    @ActivityLogger(type = ActivityType.COMMENT_DELETED)
     @Transactional
     public SuccessCode deleteComment(Long taskId, Long commentId, Long userid) {
         // 댓글조회 404에러
@@ -143,7 +143,7 @@ public class CommentService implements CommentServiceApi {
     }
 
     //댓글수정
-    @ActivityLogger(type = ActivityType.COMMENT_UPDATE)
+    @ActivityLogger(type = ActivityType.COMMENT_UPDATED)
     @Transactional
     public CommentResponse updateComment(
             Long userId,

--- a/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
@@ -28,7 +28,7 @@ public class TaskService implements TaskServiceApi {
     private final TaskRepository taskRepository;
     private final UserServiceApi userServiceApi;
 
-    @ActivityLogger(type = ActivityType.TASK_CREATE)
+    @ActivityLogger(type = ActivityType.TASK_CREATED)
     @Transactional
     public TaskResponse createTask(TaskCreateRequest request) {
 
@@ -70,7 +70,7 @@ public class TaskService implements TaskServiceApi {
     }
 
     // 태스크 상태 업데이트
-    @ActivityLogger(type = ActivityType.TASK_STATUS_CHANGE)
+    @ActivityLogger(type = ActivityType.TASK_STATUS_CHANGED)
     @Transactional
     public TaskResponse updateTaskStatus(Long taskId, TaskStatusUpdateRequest request) {
 
@@ -82,7 +82,7 @@ public class TaskService implements TaskServiceApi {
     }
 
     // 태스크 수정
-    @ActivityLogger(type = ActivityType.TASK_UPDATE)
+    @ActivityLogger(type = ActivityType.TASK_UPDATED)
     @Transactional
     public TaskResponse updateTask(Long taskId, TaskUpdateRequest request) {
 
@@ -96,7 +96,7 @@ public class TaskService implements TaskServiceApi {
     }
 
     // 태스크 삭제
-    @ActivityLogger(type = ActivityType.TASK_DELETE)
+    @ActivityLogger(type = ActivityType.TASK_DELETED)
     @Transactional
     public void deleteTask(Long taskId) {
 


### PR DESCRIPTION
## 📌 관련 이슈
> close #100 

<br>

## ✨ 작업 내용
- [x] 조회 엔드포인트 구현
- [x] Spring Data Jpa Specification을 이용한 페이지네이션, 필터링 동적 쿼리 구현
  - 사용자는 아래와 같은 값을 통해 원하는 조건으로 활동 로그를 확인할 수 있습니다.
  - 파라미터: page, size, type(활동유형), userId, taskId, 기간(startDate, endDate)
<br>

## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
