### PR TITLE
feat: Task 도메인 메서드 필요 요청 구현

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/domain/task/repository/TaskRepository.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/repository/TaskRepository.java
@@ -1,5 +1,6 @@
 package org.devlogtwo.devlog.domain.task.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.devlogtwo.devlog.common.type.TaskStatus;
 import org.devlogtwo.devlog.domain.task.entity.Task;
@@ -19,4 +20,10 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     long countByAssigneeAndStatus(User assignee, TaskStatus status);
 
     long countByAssignee(User assignee);
+
+    long countByStatus(TaskStatus status);
+
+    long countByDueDateBeforeAndStatusNot(LocalDateTime dueDate, TaskStatus status);
+
+    long countByAssigneeIdAndDueDateBetween(Long userId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskService.java
@@ -1,5 +1,6 @@
 package org.devlogtwo.devlog.domain.task.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.annotation.ActivityLogger;
@@ -164,5 +165,29 @@ public class TaskService implements TaskServiceApi {
     public long countByAssignee(User assignee) {
 
         return taskRepository.countByAssignee(assignee);
+    }
+
+    @Override
+    public long count() {
+
+        return taskRepository.count();
+    }
+
+    @Override
+    public long countByStatus(TaskStatus status) {
+
+        return taskRepository.countByStatus(status);
+    }
+
+    @Override
+    public long countByDueDateBeforeAndStatusNot(LocalDateTime dueDate, TaskStatus status) {
+
+        return taskRepository.countByDueDateBeforeAndStatusNot(dueDate, status);
+    }
+
+    @Override
+    public long countByAssigneeIdAndDueDateBetween(Long userId, LocalDateTime start, LocalDateTime end) {
+
+        return taskRepository.countByAssigneeIdAndDueDateBetween(userId, start, end);
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskServiceApi.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/task/service/TaskServiceApi.java
@@ -1,5 +1,6 @@
 package org.devlogtwo.devlog.domain.task.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.devlogtwo.devlog.common.type.TaskStatus;
 import org.devlogtwo.devlog.domain.task.entity.Task;
@@ -14,4 +15,12 @@ public interface TaskServiceApi {
     long countByAssigneeAndStatus(User assignee, TaskStatus status);
 
     long countByAssignee(User assignee);
+
+    long count();
+
+    long countByStatus(TaskStatus status);
+
+    long countByDueDateBeforeAndStatusNot(LocalDateTime dueDate, TaskStatus status);
+
+    long countByAssigneeIdAndDueDateBetween(Long userId, LocalDateTime start, LocalDateTime end);
 }


### PR DESCRIPTION
## 📌 관련 이슈
> close #109 

<br>

## ✨ 작업 내용
대시보드 통계시 필요한 Task 도메인 메서드 인터페이스 정의 및 구현
- long count();

- long countByStatus(TaskStatus status);

- long countByDueDateBeforeAndStatusNot(LocalDateTime dueDate, TaskStatus status);

- long countByAssigneeIdAndDueDateBetween(Long userId, LocalDateTime start, LocalDateTime end);

## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
