### PR TITLE
feat: 최근 활동 조회에 필요한 ActivityLog 도메인 메서드 구현

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepository.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepository.java
@@ -1,8 +1,12 @@
 package org.devlogtwo.devlog.domain.actlog.repository;
 
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long>, JpaSpecificationExecutor<ActivityLog> {
+
+    Page<ActivityLog> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class ActivityLogService {
+public class ActivityLogService implements ActivityLogServiceApi {
 
     private final ActivityLogRepository activityLogRepository;
 
@@ -41,4 +41,11 @@ public class ActivityLogService {
 
         return PageResponse.from(pages);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ActivityLog> findAllByOrderByCreatedAtDesc(Pageable pageable) {
+        return activityLogRepository.findAllByOrderByCreatedAtDesc(pageable);
+    }
+
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogServiceApi.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogServiceApi.java
@@ -1,0 +1,10 @@
+package org.devlogtwo.devlog.domain.actlog.service;
+
+import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ActivityLogServiceApi {
+
+    Page<ActivityLog> findAllByOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/src/test/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepositoryTest.java
+++ b/src/test/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepositoryTest.java
@@ -1,0 +1,100 @@
+package org.devlogtwo.devlog.domain.actlog.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.devlogtwo.devlog.common.config.JpaAuditingConfig;
+import org.devlogtwo.devlog.common.type.ActivityType;
+import org.devlogtwo.devlog.common.type.UserRole;
+import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
+import org.devlogtwo.devlog.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ActivityLogRepositoryTest {
+
+    @Autowired
+    private ActivityLogRepository activityLogRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.signUp(
+                "testuser",
+                "Test User",
+                "test@example.com",
+                "1234qwerAS!",
+                UserRole.USER
+        );
+        entityManager.persist(testUser);
+
+        ActivityLog log1 = ActivityLog.create(testUser, ActivityType.TASK_CREATED, 1L, null, "첫 번째 로그");
+        entityManager.persist(log1);
+
+        entityManager.flush();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        ActivityLog log2 = ActivityLog.create(testUser, ActivityType.TASK_UPDATED, 1L, null, "두 번째 로그");
+        entityManager.persist(log2);
+        entityManager.flush();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        ActivityLog log3 = ActivityLog.create(testUser, ActivityType.TASK_DELETED, 1L, null, "세 번째 로그");
+        entityManager.persist(log3);
+        entityManager.flush();
+    }
+
+    @Test
+    @DisplayName("findAllByOrderByCreatedAtDesc - 생성 시간 내림차순으로 모든 활동 로그를 페이지네이션하여 조회한다")
+    void findAllByOrderByCreatedAtDesc_ShouldReturnLogsInDescendingOrderOfCreation() {
+
+        // given
+        Pageable pageable = PageRequest.of(0, 5);
+
+        // when
+        Page<ActivityLog> resultPage = activityLogRepository.findAllByOrderByCreatedAtDesc(pageable);
+        List<ActivityLog> logs = resultPage.getContent();
+        for (ActivityLog log : logs) {
+            System.out.println("log.getId() = " + log.getId());
+            System.out.println("log.getDescription() = " + log.getDescription());
+            System.out.println("log.getCreatedAt() = " + log.getCreatedAt());
+        }
+
+        // then
+        assertThat(resultPage).isNotNull();
+        assertThat(logs).hasSize(3);
+
+        // 가장 나중에 생성된 '세 번째 로그'가 첫 번째로 와야 함
+        assertThat(logs.get(0).getDescription()).isEqualTo("세 번째 로그");
+        assertThat(logs.get(1).getDescription()).isEqualTo("두 번째 로그");
+        assertThat(logs.get(2).getDescription()).isEqualTo("첫 번째 로그");
+
+        // 더 확실한 검증: createdAt 타임스탬프를 직접 비교
+        assertThat(logs.get(0).getCreatedAt()).isAfter(logs.get(1).getCreatedAt());
+        assertThat(logs.get(1).getCreatedAt()).isAfter(logs.get(2).getCreatedAt());
+    }
+}

--- a/src/test/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepositoryTest.java
+++ b/src/test/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepositoryTest.java
@@ -78,11 +78,7 @@ class ActivityLogRepositoryTest {
         // when
         Page<ActivityLog> resultPage = activityLogRepository.findAllByOrderByCreatedAtDesc(pageable);
         List<ActivityLog> logs = resultPage.getContent();
-        for (ActivityLog log : logs) {
-            System.out.println("log.getId() = " + log.getId());
-            System.out.println("log.getDescription() = " + log.getDescription());
-            System.out.println("log.getCreatedAt() = " + log.getCreatedAt());
-        }
+        // Debug print statements removed for clean test code.
 
         // then
         assertThat(resultPage).isNotNull();


### PR DESCRIPTION
## 📌 관련 이슈
> close #112 

<br>

## ✨ 작업 내용

- [x] ActivityLogServiceApi 메서드 정의
- [x] ActivityLogService 메서드 구현
- [x] ActivityLogRepository 쿼리메소드 구현
 -  `Page<ActivityLog> findAllByOrderByCreatedAtDesc(Pageable pageable);` 참고
<br>

## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
