### PR TITLE
feat: 인증 기능 복구 및 개선

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/common/code/ErrorCode.java
+++ b/src/main/java/org/devlogtwo/devlog/common/code/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자가 존재하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다. 다시 로그인하세요"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토근입니다. 다시 로그인하세요."),
 
     // --- Comment Errors ---
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),

--- a/src/main/java/org/devlogtwo/devlog/common/code/ErrorCode.java
+++ b/src/main/java/org/devlogtwo/devlog/common/code/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
     PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자가 존재하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다. 다시 로그인하세요"),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토근입니다. 다시 로그인하세요."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다. 다시 로그인하세요."),
 
     // --- Comment Errors ---
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),

--- a/src/main/java/org/devlogtwo/devlog/common/config/SecurityConfig.java
+++ b/src/main/java/org/devlogtwo/devlog/common/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.devlogtwo.devlog.common.config;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.devlogtwo.devlog.common.security.CustomAuthenticationEntryPoint;
 import org.devlogtwo.devlog.common.security.JwtAuthFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +23,7 @@ public class SecurityConfig {
 
     private static final List<String> ALLOWED_ORIGINS = List.of("http://localhost:3000");
     private final JwtAuthFilter jwtAuthFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint; // ✅ 1. 커스텀 진입점 주입
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -29,32 +31,20 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        
-        // CSRF(Cross-Site Request Forgery) 보호 비활성화
-        // JWT 기반의 stateless API에서는 CSRF 보호가 불필요하므로 비활성화
-        http.csrf(AbstractHttpConfigurer::disable);
+    public SecurityFilterChain securityFilterChain(HttpSecurity http)
+            throws Exception {
 
-        // CORS 설정을 SecurityFilterChain에 통합
-        http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
-
-        // 세션 관리 방식을 Stateless로 설정
-        http.sessionManagement((sessionManagement) ->
-                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        );
-
-        // API 엔드포인트별 접근 권한 설정
-        http.authorizeHttpRequests((authorizeHttpRequests) ->
+        http.csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement((sessionManagement) ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests((authorizeHttpRequests) ->
                         authorizeHttpRequests
-                                .requestMatchers("/**").permitAll()
-//                        // '/api/auth/'로 시작하는 모든 요청은 인증 없이 허용
-//                        .requestMatchers("/api/auth/**").permitAll()
-//                        // 그 외 모든 요청은 인증이 필요함
-//                        .anyRequest().authenticated()
-        );
-
-        // JWT 인증 필터 추가
-        http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+                                .requestMatchers("/api/auth/register", "/api/auth/login").permitAll()
+                                .anyRequest().authenticated())
+                .exceptionHandling((exceptionHandling) -> exceptionHandling.authenticationEntryPoint(
+                        customAuthenticationEntryPoint))
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -63,14 +53,14 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(ALLOWED_ORIGINS); // 허용할 출처
-        configuration.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
-        configuration.addAllowedHeader("*"); // 모든 헤더 허용
-        configuration.setAllowCredentials(true); // 자격 증명 허용
+        configuration.setAllowedOrigins(ALLOWED_ORIGINS);
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 위 설정 적용
+        source.registerCorsConfiguration("/**", configuration);
         return source;
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/common/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package org.devlogtwo.devlog.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.devlogtwo.devlog.common.code.ErrorCode;
+import org.devlogtwo.devlog.common.dto.GlobalApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException)
+            throws IOException, ServletException {
+
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED_ACCESS;
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        GlobalApiResponse<Void> errorResponse = GlobalApiResponse.error(errorCode);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/common/security/JwtAuthFilter.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/JwtAuthFilter.java
@@ -1,6 +1,9 @@
 package org.devlogtwo.devlog.common.security;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,12 +11,15 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.devlogtwo.devlog.common.code.ErrorCode;
+import org.devlogtwo.devlog.common.exception.CustomBusinessException;
 import org.devlogtwo.devlog.domain.user.entity.User;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -34,32 +40,48 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         try {
-            // Header로부터 Token 추출
+
             String authHeaderValue = getAuthHeaderValue(request);
             String bearerToken = getToken(authHeaderValue);
 
-            log.info(bearerToken);
-            // 토큰 존재 여부 확인
             if (bearerToken == null) {
+                log.warn("[JwtAuthFilter] 토큰이 존재하지 않는 요청입니다.");
                 filterChain.doFilter(request, response);
-                log.info("[JwtAuthFilter] 토큰이 존재하지 않습니다.");
                 return;
             }
 
-            log.info("[JwtAuthFilter] 토큰이 존재합니다.");
             // 토큰 검증
+            log.debug("[JwtAuthFilter] 인증 요청 토큰: JWT Authenticated token: " + bearerToken);
             Claims claims = jwtTokenProvider.validateToken(bearerToken);
             String currentUsername = claims.getSubject();
-            log.info("[JwtAuthFilter] JWT Authenticated user: " + currentUsername);
+            log.debug("[JwtAuthFilter] 인증 요청 아이디: JWT Authenticated user: " + currentUsername);
 
             // 사용자 정보 추출 및 인증 객체 생성
             setAuthentication(currentUsername);
+        } catch (ExpiredJwtException e) {
+            log.warn("[JwtAuthFilter] 인증 실패: 만료된 토큰 - username={}", e.getMessage());
+            handlerExceptionResolver.resolveException(request, response, null,
+                    new CustomBusinessException(ErrorCode.EXPIRED_TOKEN));
+            return;
+        } catch (UsernameNotFoundException e) { // 토큰은 유효하지만 DB에 사용자가 없는 경우 -> 필터체인에서 url에 따라 허용 판단
+            log.warn("[JwtAuthFilter] 인증 실패: 유효하지 않은 토큰 - username={}", e.getMessage());
+        } catch (MalformedJwtException e) { // 토큰의 형식이 올바르지 않은 경우
+            log.warn("[JwtAuthFilter] 인증 실패: 유효하지 않은 토큰 - username={}", e.getMessage());
+            handlerExceptionResolver.resolveException(request, response, null,
+                    new CustomBusinessException(ErrorCode.INVALID_TOKEN));
+            return;
+        } catch (SignatureException e) { // 토큰의 시그니처가 올바르지 않은 경우
+            log.warn("[JwtAuthFilter] 인증 실패: 유효하지 않은 토큰 - username={}", e.getMessage());
+            handlerExceptionResolver.resolveException(request, response, null,
+                    new CustomBusinessException(ErrorCode.INVALID_TOKEN));
+            return;
         } catch (Exception e) {
-            handlerExceptionResolver.resolveException(request, response, null, e);
+            log.warn("[JwtAuthFilter] 인증 실패: 토큰 인증 과정 중 오류 발생 - {}", e.getMessage());
+            handlerExceptionResolver.resolveException(request, response, null,
+                    new CustomBusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
             return;
         }
 
-        // 필터 보내기
         filterChain.doFilter(request, response);
     }
 
@@ -79,21 +101,16 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         SecurityContext context = SecurityContextHolder.createEmptyContext();
 
-        // 1. 사용자 정보(UserDetails) 조회
+        // 요청마다 사용자 정보를 최신 정보로 갱신하기 위해 DB 조회 -> 회원 탈퇴시 토큰을 만료시키는 로직도 필요 없어짐
         UserDetails userDetails = jwtUserDetailsService.loadUserByUsername(username);
-
-        // 2. 비밀번호 접근 방지를 위해 별도의 JwtUserDetails가 아닌 UserPrincipal 객체 생성
+        // 비밀번호 접근 방지를 위해 별도의 JwtUserDetails가 아닌 UserPrincipal 객체 생성
         User user = ((JwtUserDetails) userDetails).getUser();
         UserPrincipal principal = UserPrincipal.from(user);
-
-        // 3. Authentication 객체 생성
-        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null,
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
                 userDetails.getAuthorities());
-
-        // 4. SecurityContext에 저장
         context.setAuthentication(authentication);
-
-        // 5. SecurityContextHolder에 최종 저장
         SecurityContextHolder.setContext(context);
         log.debug("[JwtAuthFilter] @AuthenticationPrincipal 생성 성공: " + principal.username());
     }

--- a/src/main/java/org/devlogtwo/devlog/common/security/JwtUserDetailsService.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/JwtUserDetailsService.java
@@ -1,6 +1,7 @@
 package org.devlogtwo.devlog.common.security;
 
 import lombok.RequiredArgsConstructor;
+import org.devlogtwo.devlog.common.code.ErrorCode;
 import org.devlogtwo.devlog.domain.user.entity.User;
 import org.devlogtwo.devlog.domain.user.service.UserServiceApi;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -18,7 +19,8 @@ public class JwtUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userService.findUserByUsername(username);
+        User user = userService.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException(ErrorCode.USER_NOT_FOUND.getMessage(username)));
 
         return JwtUserDetails.builder()
                 .user(user)

--- a/src/main/java/org/devlogtwo/devlog/domain/user/entity/User.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/user/entity/User.java
@@ -28,10 +28,10 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 20)
     private String username;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String name;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/org/devlogtwo/devlog/domain/user/service/UserService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package org.devlogtwo.devlog.domain.user.service;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.code.ErrorCode;
 import org.devlogtwo.devlog.common.exception.CustomBusinessException;
@@ -34,6 +35,11 @@ public class UserService implements UserServiceApi {
     public User findUserByUsername(String username) {
         return userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomBusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Override
+    public Optional<User> findByUsername(String username) {
+        return userRepository.findByUsername(username);
     }
 
     @Override

--- a/src/main/java/org/devlogtwo/devlog/domain/user/service/UserServiceApi.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/user/service/UserServiceApi.java
@@ -1,6 +1,7 @@
 package org.devlogtwo.devlog.domain.user.service;
 
 import java.util.List;
+import java.util.Optional;
 import org.devlogtwo.devlog.domain.user.entity.User;
 
 public interface UserServiceApi {
@@ -20,4 +21,6 @@ public interface UserServiceApi {
     User registerNewUser(User user);
 
     void deleteUser(User user);
+
+    Optional<User> findByUsername(String username);
 }


### PR DESCRIPTION
## 📌 관련 이슈
> close #114 

<br>

## ✨ 작업 내용

- [x] 회원가입, 로그인 제외하면 모두 인증 필요하도록 설정
- [x] token & user -> 로그인 | token만 있는 경우 회원가입, 로그인은 가능하도록 수정
- [x] 인증 로거 레벨 debug로 수정
- [x] 회원 탈퇴 시 토큰 강제 만료 여러 방법 중 구현 -> 매 요청마다 토큰으로 user정보를 확인하므로 필요 없음
- [x] entity 제약 조건 추가
<br>

## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
