### PR TITLE
refactor: Activity Log 엔티티 수정 및 JPA 성능 개선

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/common/util/DescriptionGenerator.java
+++ b/src/main/java/org/devlogtwo/devlog/common/util/DescriptionGenerator.java
@@ -1,0 +1,61 @@
+package org.devlogtwo.devlog.common.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.devlogtwo.devlog.common.type.ActivityType;
+import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class DescriptionGenerator {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public static String createDescription(ActivityLog activityLog) {
+        ActivityType type = activityLog.getType();
+        String resultJson = activityLog.getResult();
+
+        // comment 삭제와 task 삭제의 result가 달라서 별도로 먼저 처리
+        if (type == ActivityType.TASK_DELETED || type == ActivityType.COMMENT_DELETED) {
+            return getDefaultDescription(activityLog);
+        }
+
+        try {
+            if (resultJson == null || resultJson.equals("N/A")) {
+                return getDefaultDescription(activityLog);
+            }
+
+            JsonNode resultNode = mapper.readTree(resultJson);
+
+            return switch (type) {
+                case TASK_CREATED -> {
+                    String title = resultNode.path("title").asText("알 수 없는 작업");
+                    yield String.format("새로운 작업 '%s'을 생성했습니다.", title);
+                }
+                case TASK_UPDATED -> "작업 정보를 수정했습니다.";
+                case TASK_STATUS_CHANGED -> {
+                    String before = resultNode.path("before").asText("이전 상태");
+                    String after = resultNode.path("after").path("status").asText("현재 상태");
+                    yield String.format("작업 상태를 '%s'에서 '%s'로 변경했습니다.", before, after);
+                }
+                case COMMENT_CREATED -> "작업에 댓글을 작성했습니다.";
+                case COMMENT_UPDATED -> "댓글을 수정했습니다.";
+                default -> getDefaultDescription(activityLog);
+            };
+        } catch (Exception e) {
+            log.warn("[DescriptionGenerator] 로그 설명 생성 중 오류 발생: type={}, result={}, error={}",
+                    type, resultJson, e.getMessage());
+            return type.getDescription();
+        }
+    }
+
+    private static String getDefaultDescription(ActivityLog activityLog) {
+        return switch (activityLog.getType()) {
+            case TASK_DELETED -> "작업을 삭제했습니다.";
+            case COMMENT_DELETED -> "댓글을 삭제했습니다.";
+            default -> activityLog.getType().getDescription();
+        };
+    }
+}

--- a/src/main/java/org/devlogtwo/devlog/common/util/DescriptionGenerator.java
+++ b/src/main/java/org/devlogtwo/devlog/common/util/DescriptionGenerator.java
@@ -2,6 +2,7 @@ package org.devlogtwo.devlog.common.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.devlogtwo.devlog.common.type.ActivityType;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
@@ -9,11 +10,12 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class DescriptionGenerator {
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
-    public static String createDescription(ActivityLog activityLog) {
+    public String createDescription(ActivityLog activityLog) {
         ActivityType type = activityLog.getType();
         String resultJson = activityLog.getResult();
 
@@ -27,7 +29,7 @@ public class DescriptionGenerator {
                 return getDefaultDescription(activityLog);
             }
 
-            JsonNode resultNode = mapper.readTree(resultJson);
+            JsonNode resultNode = objectMapper.readTree(resultJson);
 
             return switch (type) {
                 case TASK_CREATED -> {
@@ -51,7 +53,7 @@ public class DescriptionGenerator {
         }
     }
 
-    private static String getDefaultDescription(ActivityLog activityLog) {
+    private String getDefaultDescription(ActivityLog activityLog) {
         return switch (activityLog.getType()) {
             case TASK_DELETED -> "작업을 삭제했습니다.";
             case COMMENT_DELETED -> "댓글을 삭제했습니다.";

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/aop/ActivityLogAspect.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/aop/ActivityLogAspect.java
@@ -15,8 +15,6 @@ import org.devlogtwo.devlog.domain.comment.dto.response.CommentResponse;
 import org.devlogtwo.devlog.domain.task.dto.response.TaskResponse;
 import org.devlogtwo.devlog.domain.task.entity.Task;
 import org.devlogtwo.devlog.domain.task.service.TaskService;
-import org.devlogtwo.devlog.domain.user.entity.User;
-import org.devlogtwo.devlog.domain.user.service.UserService;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -28,8 +26,7 @@ import org.springframework.stereotype.Component;
 public class ActivityLogAspect {
 
     private final ActivityLogService activityLogService;
-    private final UserService userService; // User 엔티티 조회용
-    private final TaskService taskService; // Task의 변경 전 상태 조회용
+    private final TaskService taskService; // Task의 변경 전 상태 조회를 위해 필요
 
     @Pointcut("@annotation(activityLogger)")
     public void activityLogPointcut(ActivityLogger activityLogger) {
@@ -38,13 +35,13 @@ public class ActivityLogAspect {
     @Around("activityLogPointcut(activityLogger)")
     public Object logActivity(ProceedingJoinPoint joinPoint, ActivityLogger activityLogger) throws Throwable {
 
-        User currentUser = getCurrentUser();
-        if (currentUser == null) {
-            log.warn("로그를 기록할 사용자 정보를 찾을 수 없어, 대상 메소드만 실행합니다.");
+        UserPrincipal currentUserPrincipal = getCurrentUserPrincipal();
+        if (currentUserPrincipal == null) {
+            log.warn("[ActivityLogAspect] 로그를 기록할 사용자 정보를 찾을 수 없어, 대상 메소드만 실행합니다.");
             return joinPoint.proceed();
         }
 
-        // TASK_STATUS_CHANGE 경우에만 사용
+        // Type이 TASK_STATUS_CHANGE 경우에만 사용
         String beforeState = getBeforeState(activityLogger.type(), joinPoint);
 
         Object result = joinPoint.proceed();
@@ -54,28 +51,28 @@ public class ActivityLogAspect {
             Long commentId = extractId(joinPoint, result, "commentId");
             String description = createLogDescription(activityLogger.type(), result, beforeState);
 
-            activityLogService.saveLog(currentUser, activityLogger.type(), taskId, commentId, description);
+            activityLogService.saveLog(currentUserPrincipal.id(), activityLogger.type(), taskId, commentId,
+                    description);
+
             log.info("[ActivityLogAspect]: Success - [User: {}] [Type: {}] [Description: {}]",
-                    currentUser.getUsername(),
+                    currentUserPrincipal.username(),
                     activityLogger.type().name(), description);
 
         } catch (Exception e) {
-            // 로깅으로 인해 종료되지 않도록 예외를 새로 던지지는 않음
+            // 로깅으로 인해 대상 메서드가 종료되지 않도록 예외를 새로 던지지는 않음
             log.error("[ActivityLogAspect]", e);
         }
 
         return result;
     }
 
-    // TODO: 매 번 조회하고 있어 더 좋은 방법이 있나 고민 필요
-    // 여기서 조회를 안 하고 userId만 넘기면 결국 서비스에서 어차피 하게 됨 위치가 어디가 나은지?
-    private User getCurrentUser() {
-
+    // User 엔티티를 매 번 조회하는 대신 UserPrincipal을 사용하여 db 조회가 이뤄지지 않도록 개선
+    private UserPrincipal getCurrentUserPrincipal() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !(authentication.getPrincipal() instanceof UserPrincipal principal)) {
-            return null;
+        if (authentication != null && authentication.getPrincipal() instanceof UserPrincipal principal) {
+            return principal;
         }
-        return userService.findUserById(principal.id());
+        return null;
     }
 
     private String getBeforeState(ActivityType type, ProceedingJoinPoint joinPoint) {
@@ -86,7 +83,7 @@ public class ActivityLogAspect {
 
         Long taskId = findArgumentByName(joinPoint, "taskId", Long.class);
 
-        // 결국 이전 상태를 알기 위해서는 조회를 해와야함..
+        // 결국 이전 상태를 알기 위해서는 조회 필요
         if (taskId != null) {
             Task task = taskService.findTaskById(taskId);
             return task.getStatus().name();

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/aop/ActivityLogAspect.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/aop/ActivityLogAspect.java
@@ -1,5 +1,10 @@
 package org.devlogtwo.devlog.domain.actlog.aop;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -13,7 +18,6 @@ import org.devlogtwo.devlog.common.type.ActivityType;
 import org.devlogtwo.devlog.domain.actlog.service.ActivityLogService;
 import org.devlogtwo.devlog.domain.comment.dto.response.CommentResponse;
 import org.devlogtwo.devlog.domain.task.dto.response.TaskResponse;
-import org.devlogtwo.devlog.domain.task.entity.Task;
 import org.devlogtwo.devlog.domain.task.service.TaskService;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,6 +31,7 @@ public class ActivityLogAspect {
 
     private final ActivityLogService activityLogService;
     private final TaskService taskService; // Task의 변경 전 상태 조회를 위해 필요
+    private final ObjectMapper objectMapper;
 
     @Pointcut("@annotation(activityLogger)")
     public void activityLogPointcut(ActivityLogger activityLogger) {
@@ -44,27 +49,24 @@ public class ActivityLogAspect {
         // Type이 TASK_STATUS_CHANGE 경우에만 사용
         String beforeState = getBeforeState(activityLogger.type(), joinPoint);
 
-        Object result = joinPoint.proceed();
+        Object result = null;
+        boolean success = true;
+        Exception exceptionHandler = null;
 
         try {
-            Long taskId = extractId(joinPoint, result, "taskId");
-            Long commentId = extractId(joinPoint, result, "commentId");
-            String description = createLogDescription(activityLogger.type(), result, beforeState);
-
-            activityLogService.saveLog(currentUserPrincipal.id(), activityLogger.type(), taskId, commentId,
-                    description);
-
-            log.info("[ActivityLogAspect]: Success - [User: {}] [Type: {}] [Description: {}]",
-                    currentUserPrincipal.username(),
-                    activityLogger.type().name(), description);
-
+            result = joinPoint.proceed(); // 2. 대상 메서드 실행
+//            return result;
         } catch (Exception e) {
-            // 로깅으로 인해 대상 메서드가 종료되지 않도록 예외를 새로 던지지는 않음
-            log.error("[ActivityLogAspect]", e);
+            success = false;
+            result = e.getClass().getSimpleName() + ": " + e.getMessage();
+            exceptionHandler = e;
+            throw e;
+        } finally {
+            recordLog(joinPoint, activityLogger, currentUserPrincipal, success, beforeState, result, exceptionHandler);
         }
-
         return result;
     }
+
 
     // User 엔티티를 매 번 조회하는 대신 UserPrincipal을 사용하여 db 조회가 이뤄지지 않도록 개선
     private UserPrincipal getCurrentUserPrincipal() {
@@ -75,6 +77,51 @@ public class ActivityLogAspect {
         return null;
     }
 
+    private void recordLog(ProceedingJoinPoint joinPoint, ActivityLogger logger, UserPrincipal principal,
+                           boolean success, String beforeState, Object result, Exception exception) {
+        try {
+            MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+            String methodName = signature.toShortString();
+            String params = getParamsAsString(joinPoint.getArgs());
+
+            Long taskId = extractId(joinPoint, result, "taskId");
+            Long commentId = extractId(joinPoint, result, "commentId");
+            String exceptionStr = (exception != null) ? exception.getClass().getSimpleName() : "None";
+
+            String resultStr;
+            if (success) {
+                // 성공 시, void 메서드(result=null)는 JSON "null"로, 나머지는 객체를 JSON으로 변환
+                resultStr = (result != null) ? objectMapper.writeValueAsString(result) : "null";
+            } else {
+                // 실패 시, 예외 정보를 JSON 문자열로 변환
+                resultStr = objectMapper.writeValueAsString(
+                        exception.getClass().getSimpleName() + ": " + exception.getMessage());
+            }
+
+            if (logger.type() == ActivityType.TASK_STATUS_CHANGED && result instanceof TaskResponse) {
+                Map<String, Object> statusChangeMap = Map.of(
+                        "before", beforeState,
+                        "after", result
+                );
+                resultStr = objectMapper.writeValueAsString(statusChangeMap);
+            }
+
+            log.info(
+                    "[ActivityLog] [User: {}, Method: {}, Params: {}, Success: {}, ExecutionTime: {}ms, Exception: {}]",
+                    principal.username(),
+                    methodName,
+                    params,
+                    success,
+                    LocalDateTime.now(),
+                    exceptionStr
+            );
+            activityLogService.saveLog(principal.id(), logger.type(), methodName, params, success, resultStr,
+                    taskId, commentId);
+        } catch (Exception e) {
+            log.error("[ActivityLogAspect] 로그 기록 중 오류 발생", e);
+        }
+    }
+
     private String getBeforeState(ActivityType type, ProceedingJoinPoint joinPoint) {
 
         if (type != ActivityType.TASK_STATUS_CHANGED) {
@@ -83,46 +130,11 @@ public class ActivityLogAspect {
 
         Long taskId = findArgumentByName(joinPoint, "taskId", Long.class);
 
-        // 결국 이전 상태를 알기 위해서는 조회 필요
+        // 결국 이전 상태를 알기 위해서는 task db 조회 필요
         if (taskId != null) {
-            Task task = taskService.findTaskById(taskId);
-            return task.getStatus().name();
+            return taskService.findTaskById(taskId).getStatus().name();
         }
         return null;
-    }
-
-    private String createLogDescription(ActivityType type, Object result, String beforeState) {
-
-        if (result instanceof TaskResponse task) {
-            switch (type) {
-                case TASK_CREATED:
-                    return String.format("새로운 작업 '%s'을 생성했습니다.", task.title());
-                case TASK_UPDATED:
-                    return "작업 정보를 수정했습니다.";
-                case TASK_STATUS_CHANGED:
-                    if (beforeState != null) {
-                        return String.format("작업 상태를 '%s'에서 '%s'로 변경했습니다.", beforeState,
-                                task.status());
-                    }
-                    return String.format("작업 상태를 '%s'로 변경했습니다.", task.status());
-            }
-        } else if (result instanceof CommentResponse comment) {
-            switch (type) {
-                case COMMENT_CREATED:
-                    return "작업에 댓글을 작성했습니다.";
-                case COMMENT_UPDATED:
-                    return "댓글을 수정했습니다.";
-            }
-        } else {
-            switch (type) {
-                case TASK_DELETED:
-                    return "작업을 삭제했습니다.";
-                case COMMENT_DELETED:
-                    return "댓글을 삭제했습니다.";
-            }
-        }
-
-        return type.getDescription();
     }
 
     private Long extractId(ProceedingJoinPoint joinPoint, Object result, String idName) {
@@ -161,5 +173,31 @@ public class ActivityLogAspect {
             }
         }
         return null;
+    }
+
+    private String getParamsAsString(Object[] args) {
+        if (args == null || args.length == 0) {
+            return "[]";
+        }
+        try {
+            return Arrays.stream(args)
+                    .map(obj -> {
+                        try {
+                            // DTO 객체 등에 password 필드가 포함된 경우를 고려하여 문자열 검사
+                            String jsonStr = objectMapper.writeValueAsString(obj);
+                            if (jsonStr.toLowerCase().contains("\"password\"")) {
+                                return "FILTERED_SENSITIVE_INFO";
+                            }
+                            return jsonStr;
+                        } catch (Exception e) {
+                            // 직렬화할 수 없는 객체는 클래스 이름만 로깅
+                            return obj.getClass().getSimpleName();
+                        }
+                    })
+                    .collect(Collectors.joining(", "));
+        } catch (Exception e) {
+            log.warn("[ActivityLogAspect] 파라미터를 문자열로 변환하는 중 오류 발생", e);
+            return "ParamConversionError";
+        }
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/aop/ActivityLogAspect.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/aop/ActivityLogAspect.java
@@ -55,7 +55,6 @@ public class ActivityLogAspect {
 
         try {
             result = joinPoint.proceed(); // 2. 대상 메서드 실행
-//            return result;
         } catch (Exception e) {
             success = false;
             result = e.getClass().getSimpleName() + ": " + e.getMessage();

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/controller/ActivityLogController.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/controller/ActivityLogController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.code.SuccessCode;
 import org.devlogtwo.devlog.common.dto.GlobalApiResponse;
 import org.devlogtwo.devlog.common.dto.PageResponse;
+import org.devlogtwo.devlog.common.security.UserPrincipal;
 import org.devlogtwo.devlog.common.type.ActivityType;
 import org.devlogtwo.devlog.common.util.ResponseHelper;
 import org.devlogtwo.devlog.domain.actlog.dto.response.ActivityLogResponse;
@@ -14,6 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,6 +28,7 @@ public class ActivityLogController {
 
     @GetMapping("/api/activities")
     public ResponseEntity<GlobalApiResponse<PageResponse<ActivityLogResponse>>> getActivities(
+            @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam(required = false) ActivityType type,
             @RequestParam(required = false) Long userId,
             @RequestParam(required = false) Long taskId,
@@ -34,7 +37,7 @@ public class ActivityLogController {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable) {
 
-        PageResponse<ActivityLogResponse> logPage = activityLogService.getActivityLogs(type, userId, taskId,
+        PageResponse<ActivityLogResponse> logPage = activityLogService.getActivityLogs(principal, type, userId, taskId,
                 startDate, endDate, pageable);
         return ResponseHelper.success(SuccessCode.ACTIVITY_LOG_SUCCESS, logPage);
     }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/dto/response/ActivityLogResponse.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/dto/response/ActivityLogResponse.java
@@ -2,6 +2,7 @@ package org.devlogtwo.devlog.domain.actlog.dto.response;
 
 import java.time.LocalDateTime;
 import org.devlogtwo.devlog.common.type.ActivityType;
+import org.devlogtwo.devlog.common.util.DescriptionGenerator;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.devlogtwo.devlog.domain.user.dto.response.UserDetailsResponse;
 
@@ -22,7 +23,7 @@ public record ActivityLogResponse(
                 UserDetailsResponse.from(log.getUser()),
                 log.getTaskId(),
                 log.getCreatedAt(),
-                log.getDescription()
+                DescriptionGenerator.createDescription(log)
         );
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/dto/response/ActivityLogResponse.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/dto/response/ActivityLogResponse.java
@@ -2,7 +2,6 @@ package org.devlogtwo.devlog.domain.actlog.dto.response;
 
 import java.time.LocalDateTime;
 import org.devlogtwo.devlog.common.type.ActivityType;
-import org.devlogtwo.devlog.common.util.DescriptionGenerator;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.devlogtwo.devlog.domain.user.dto.response.UserDetailsResponse;
 
@@ -15,7 +14,7 @@ public record ActivityLogResponse(
         LocalDateTime timestamp,
         String description
 ) {
-    public static ActivityLogResponse from(ActivityLog log) {
+    public static ActivityLogResponse of(ActivityLog log, String description) {
         return new ActivityLogResponse(
                 log.getId(),
                 log.getType(),
@@ -23,7 +22,7 @@ public record ActivityLogResponse(
                 UserDetailsResponse.from(log.getUser()),
                 log.getTaskId(),
                 log.getCreatedAt(),
-                DescriptionGenerator.createDescription(log)
+                description
         );
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/entity/ActivityLog.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/entity/ActivityLog.java
@@ -14,7 +14,6 @@ import jakarta.persistence.NamedAttributeNode;
 import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -45,14 +44,20 @@ public class ActivityLog {
     @Column(nullable = false, length = 50)
     private ActivityType type;
 
-    @Column(nullable = false)
     private Long taskId;
 
     private Long commentId;
 
-    @NotNull
-    @Column(nullable = false)
-    private String description;
+    @Column
+    private String methodName;
+
+    @Column(columnDefinition = "TEXT")
+    private String parameters;
+
+    @Column(columnDefinition = "TEXT")
+    private String result;
+
+    private boolean success;
 
     @CreatedDate
     @Column(updatable = false)
@@ -60,21 +65,29 @@ public class ActivityLog {
     private LocalDateTime createdAt;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private ActivityLog(User user, ActivityType type, Long taskId, Long commentId, String description) {
+    private ActivityLog(User user, ActivityType type, String methodName, String parameters, boolean success,
+                        String result, Long taskId, Long commentId) {
         this.user = user;
+        this.type = type;
+        this.methodName = methodName;
+        this.parameters = parameters;
+        this.success = success;
+        this.result = result;
         this.taskId = taskId;
         this.commentId = commentId;
-        this.type = type;
-        this.description = description;
     }
 
-    public static ActivityLog create(User user, ActivityType type, Long taskId, Long commentId, String description) {
+    public static ActivityLog create(User user, ActivityType type, String methodName, String parameters,
+                                     boolean success, String result, Long taskId, Long commentId) {
         return ActivityLog.builder()
                 .user(user)
+                .type(type)
+                .methodName(methodName)
+                .parameters(parameters)
+                .success(success)
+                .result(result)
                 .taskId(taskId)
                 .commentId(commentId)
-                .type(type)
-                .description(description)
                 .build();
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/entity/ActivityLog.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/entity/ActivityLog.java
@@ -10,6 +10,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import jakarta.validation.constraints.NotNull;
@@ -27,6 +29,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@NamedEntityGraph(
+        name = "ActivityLog.withUser",
+        attributeNodes = @NamedAttributeNode("user"))
 public class ActivityLog {
 
     @Id

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepository.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepository.java
@@ -3,10 +3,17 @@ package org.devlogtwo.devlog.domain.actlog.repository;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long>, JpaSpecificationExecutor<ActivityLog> {
 
+    @EntityGraph(value = "ActivityLog.withUser")
     Page<ActivityLog> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    @Override
+    @EntityGraph(value = "ActivityLog.withUser")
+    Page<ActivityLog> findAll(Specification<ActivityLog> spec, Pageable pageable);
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
@@ -6,6 +6,7 @@ import org.devlogtwo.devlog.common.dto.PageResponse;
 import org.devlogtwo.devlog.common.security.UserPrincipal;
 import org.devlogtwo.devlog.common.type.ActivityType;
 import org.devlogtwo.devlog.common.type.UserRole;
+import org.devlogtwo.devlog.common.util.DescriptionGenerator;
 import org.devlogtwo.devlog.domain.actlog.dto.response.ActivityLogResponse;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.devlogtwo.devlog.domain.actlog.repository.ActivityLogRepository;
@@ -24,6 +25,7 @@ public class ActivityLogService implements ActivityLogServiceApi {
 
     private final ActivityLogRepository activityLogRepository;
     private final UserServiceApi userService;
+    private final DescriptionGenerator descriptionGenerator;
 
     @Transactional
     public void saveLog(Long userId, ActivityType type, String methodName, String parameters, boolean success,
@@ -50,7 +52,8 @@ public class ActivityLogService implements ActivityLogServiceApi {
                 .buildSpec(type, targetUserId, taskId, startDate, endDate);
 
         Page<ActivityLogResponse> pages = activityLogRepository.findAll(spec, pageable)
-                .map(ActivityLogResponse::from);
+                .map(activityLog -> ActivityLogResponse.of(activityLog,
+                        descriptionGenerator.createDescription(activityLog)));
 
         return PageResponse.from(pages);
     }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
@@ -3,7 +3,9 @@ package org.devlogtwo.devlog.domain.actlog.service;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.dto.PageResponse;
+import org.devlogtwo.devlog.common.security.UserPrincipal;
 import org.devlogtwo.devlog.common.type.ActivityType;
+import org.devlogtwo.devlog.common.type.UserRole;
 import org.devlogtwo.devlog.domain.actlog.dto.response.ActivityLogResponse;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.devlogtwo.devlog.domain.actlog.repository.ActivityLogRepository;
@@ -29,12 +31,18 @@ public class ActivityLogService implements ActivityLogServiceApi {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<ActivityLogResponse> getActivityLogs(ActivityType type, Long userId, Long taskId,
+    public PageResponse<ActivityLogResponse> getActivityLogs(UserPrincipal principal, ActivityType type, Long userId,
+                                                             Long taskId,
                                                              LocalDate startDate, LocalDate endDate,
                                                              Pageable pageable) {
 
+        Long targetUserId = userId; // 권한이 ADMIN인 경우는 필터링 조건인 userId가 null이면 모두 조회, NULL이 아니면 userId 조회
+        if (principal.role() == UserRole.USER) { // 권한이 USER인 경우는 자기 내용만 조회하도록 강제
+            targetUserId = principal.id();
+        }
+
         Specification<ActivityLog> spec = ActivityLogSpecs
-                .buildSpec(type, userId, taskId, startDate, endDate);
+                .buildSpec(type, targetUserId, taskId, startDate, endDate);
 
         Page<ActivityLogResponse> pages = activityLogRepository.findAll(spec, pageable)
                 .map(ActivityLogResponse::from);

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
@@ -26,10 +26,12 @@ public class ActivityLogService implements ActivityLogServiceApi {
     private final UserServiceApi userService;
 
     @Transactional
-    public void saveLog(Long userId, ActivityType type, Long taskId, Long commentId, String description) {
+    public void saveLog(Long userId, ActivityType type, String methodName, String parameters, boolean success,
+                        String result, Long taskId, Long commentId) {
 
         User userProxy = userService.getReferenceById(userId);
-        ActivityLog newActivityLog = ActivityLog.create(userProxy, type, taskId, commentId, description);
+        ActivityLog newActivityLog = ActivityLog.create(userProxy, type, methodName, parameters, success, result,
+                taskId, commentId);
         activityLogRepository.save(newActivityLog);
     }
 

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
@@ -11,6 +11,7 @@ import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.devlogtwo.devlog.domain.actlog.repository.ActivityLogRepository;
 import org.devlogtwo.devlog.domain.actlog.specs.ActivityLogSpecs;
 import org.devlogtwo.devlog.domain.user.entity.User;
+import org.devlogtwo.devlog.domain.user.service.UserServiceApi;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -22,11 +23,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class ActivityLogService implements ActivityLogServiceApi {
 
     private final ActivityLogRepository activityLogRepository;
+    private final UserServiceApi userService;
 
     @Transactional
-    public void saveLog(User currentUser, ActivityType type, Long taskId, Long commentId, String description) {
+    public void saveLog(Long userId, ActivityType type, Long taskId, Long commentId, String description) {
 
-        ActivityLog newActivityLog = ActivityLog.create(currentUser, type, taskId, commentId, description);
+        User userProxy = userService.getReferenceById(userId);
+        ActivityLog newActivityLog = ActivityLog.create(userProxy, type, taskId, commentId, description);
         activityLogRepository.save(newActivityLog);
     }
 

--- a/src/main/java/org/devlogtwo/devlog/domain/auth/service/AuthService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/auth/service/AuthService.java
@@ -15,6 +15,7 @@ import org.devlogtwo.devlog.domain.user.entity.User;
 import org.devlogtwo.devlog.domain.user.service.UserServiceApi;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +25,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Transactional
     public AuthRegisterResponse signUp(AuthRegisterRequest authRegisterRequest) {
 
         if (userService.isUsernameTaken(authRegisterRequest.username())) {
@@ -43,6 +45,7 @@ public class AuthService {
         return AuthRegisterResponse.from(savedUser);
     }
 
+    @Transactional
     public AuthLoginResponse login(AuthLoginRequest authLoginRequest) {
 
         User user = userService.findUserByUsername(authLoginRequest.username());
@@ -55,6 +58,7 @@ public class AuthService {
         return AuthLoginResponse.from(token);
     }
 
+    @Transactional
     public void withdraw(@Valid AuthWithdrawRequest authWithdrawRequest, Long userId) {
 
         User user = userService.findUserById(userId);

--- a/src/main/java/org/devlogtwo/devlog/domain/dashboard/dto/response/DashboardRecentActivityResponse.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/dashboard/dto/response/DashboardRecentActivityResponse.java
@@ -2,7 +2,6 @@ package org.devlogtwo.devlog.domain.dashboard.dto.response;
 
 import java.time.LocalDateTime;
 import org.devlogtwo.devlog.common.type.ActivityType;
-import org.devlogtwo.devlog.common.util.DescriptionGenerator;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.devlogtwo.devlog.domain.user.entity.User;
 
@@ -16,7 +15,7 @@ public record DashboardRecentActivityResponse(
         String description,
         LocalDateTime createdAt
 ) {
-    public static DashboardRecentActivityResponse from(ActivityLog activityLog) {
+    public static DashboardRecentActivityResponse of(ActivityLog activityLog, String description) {
 
         String targetType;
         ActivityType activityType = activityLog.getType();
@@ -31,7 +30,7 @@ public record DashboardRecentActivityResponse(
                 activityLog.getId(), activityLog.getUser() != null ? activityLog.getUser().getId() : null,
                 UserInfo.from(activityLog.getUser()),
                 activityLog.getType().name(), targetType, activityLog.getTaskId(),
-                DescriptionGenerator.createDescription(activityLog),
+                description,
                 activityLog.getCreatedAt());
     }
 

--- a/src/main/java/org/devlogtwo/devlog/domain/dashboard/dto/response/DashboardRecentActivityResponse.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/dashboard/dto/response/DashboardRecentActivityResponse.java
@@ -2,6 +2,7 @@ package org.devlogtwo.devlog.domain.dashboard.dto.response;
 
 import java.time.LocalDateTime;
 import org.devlogtwo.devlog.common.type.ActivityType;
+import org.devlogtwo.devlog.common.util.DescriptionGenerator;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.devlogtwo.devlog.domain.user.entity.User;
 
@@ -15,19 +16,6 @@ public record DashboardRecentActivityResponse(
         String description,
         LocalDateTime createdAt
 ) {
-    public record UserInfo(
-            Long id,
-            String name
-    ) {
-        public static UserInfo from(User user) {
-            if (user == null) {
-                return null;
-            }
-
-            return new UserInfo(user.getId(), user.getName());
-        }
-    }
-
     public static DashboardRecentActivityResponse from(ActivityLog activityLog) {
 
         String targetType;
@@ -42,7 +30,21 @@ public record DashboardRecentActivityResponse(
         return new DashboardRecentActivityResponse(
                 activityLog.getId(), activityLog.getUser() != null ? activityLog.getUser().getId() : null,
                 UserInfo.from(activityLog.getUser()),
-                activityLog.getType().name(), targetType, activityLog.getTaskId(), activityLog.getDescription(),
+                activityLog.getType().name(), targetType, activityLog.getTaskId(),
+                DescriptionGenerator.createDescription(activityLog),
                 activityLog.getCreatedAt());
+    }
+
+    public record UserInfo(
+            Long id,
+            String name
+    ) {
+        public static UserInfo from(User user) {
+            if (user == null) {
+                return null;
+            }
+
+            return new UserInfo(user.getId(), user.getName());
+        }
     }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/dashboard/service/DashBoardService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/dashboard/service/DashBoardService.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.dto.PageResponse;
 import org.devlogtwo.devlog.common.type.TaskStatus;
+import org.devlogtwo.devlog.common.util.DescriptionGenerator;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.devlogtwo.devlog.domain.actlog.service.ActivityLogServiceApi;
 import org.devlogtwo.devlog.domain.dashboard.dto.response.DashboardRecentActivityResponse;
@@ -35,6 +36,7 @@ public class DashBoardService {
     private final TeamMemberServiceApi teamMemberService;
     private final TeamServiceApi teamService;
     private final ActivityLogServiceApi activityLogServiceApi;
+    private final DescriptionGenerator descriptionGenerator;
 
     //대시보드 통계 조회
     public DashboardStatsResponse getStats(Long id) {
@@ -128,7 +130,9 @@ public class DashBoardService {
 
         Page<ActivityLog> activityLogPage = activityLogServiceApi.findAllByOrderByCreatedAtDesc(pageable);
 
-        Page<DashboardRecentActivityResponse> responsePage = activityLogPage.map(DashboardRecentActivityResponse::from);
+        Page<DashboardRecentActivityResponse> responsePage = activityLogPage
+                .map(activityLog -> DashboardRecentActivityResponse.of(activityLog,
+                        descriptionGenerator.createDescription(activityLog)));
 
         return PageResponse.from(responsePage);
     }

--- a/src/main/java/org/devlogtwo/devlog/domain/user/service/UserService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/user/service/UserService.java
@@ -81,4 +81,10 @@ public class UserService implements UserServiceApi {
                 .map(UserAssignableResponse::from)
                 .toList();
     }
+
+    // Activity Log 저장 시 불필요한 User 조회를 막기 위해 proxy 객체 조회 사용
+    @Override
+    public User getReferenceById(Long userId) {
+        return userRepository.getReferenceById(userId);
+    }
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/user/service/UserServiceApi.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/user/service/UserServiceApi.java
@@ -23,4 +23,6 @@ public interface UserServiceApi {
     void deleteUser(User user);
 
     Optional<User> findByUsername(String username);
+
+    User getReferenceById(Long userId);
 }


### PR DESCRIPTION
## 📌 관련 이슈
> close #138 
<br>

## ✨ 작업 내용
- [x] ActivityLog 확인시 내 로그만 확인할 수 있도록 수정
- [x] Admin 권한은 모든 유저의 로그를 확인할 수 있도록 수정
- [x] ActivityLog 조회시 User에 대한 N+1 문제 해결
- [x] ActivityLog AOP 기록 및 엔티티 저장 시 발생하는 불필요한 User 엔티티 조회 해결
- [x] ActivityLog 엔티티 필드 수정, description은 저장하지 않고 DTO 반환시 필요한 서비스에서 생성하도록 수정
<br>


## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
