### PR TITLE
fix: 대시보드의 활동 피드에서 본인의 로그만 조회되도록 수정

### DIFF
--- a/src/main/java/org/devlogtwo/devlog/common/config/SecurityConfig.java
+++ b/src/main/java/org/devlogtwo/devlog/common/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
 
     private static final List<String> ALLOWED_ORIGINS = List.of("http://localhost:3000");
     private final JwtAuthFilter jwtAuthFilter;
-    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint; // ✅ 1. 커스텀 진입점 주입
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/org/devlogtwo/devlog/common/security/JwtAuthFilter.java
+++ b/src/main/java/org/devlogtwo/devlog/common/security/JwtAuthFilter.java
@@ -45,7 +45,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             String bearerToken = getToken(authHeaderValue);
 
             if (bearerToken == null) {
-                log.warn("[JwtAuthFilter] 토큰이 존재하지 않는 요청입니다.");
+                log.debug("[JwtAuthFilter] 토큰이 존재하지 않는 요청입니다.");
                 filterChain.doFilter(request, response);
                 return;
             }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepository.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/repository/ActivityLogRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long>, JpaSpecificationExecutor<ActivityLog> {
 
     @EntityGraph(value = "ActivityLog.withUser")
-    Page<ActivityLog> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Page<ActivityLog> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     @Override
     @EntityGraph(value = "ActivityLog.withUser")

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogService.java
@@ -60,8 +60,7 @@ public class ActivityLogService implements ActivityLogServiceApi {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ActivityLog> findAllByOrderByCreatedAtDesc(Pageable pageable) {
-        return activityLogRepository.findAllByOrderByCreatedAtDesc(pageable);
+    public Page<ActivityLog> getMyFeedActivities(UserPrincipal currentUser, Pageable pageable) {
+        return activityLogRepository.findAllByUserIdOrderByCreatedAtDesc(currentUser.id(), pageable);
     }
-
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogServiceApi.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/actlog/service/ActivityLogServiceApi.java
@@ -1,10 +1,11 @@
 package org.devlogtwo.devlog.domain.actlog.service;
 
+import org.devlogtwo.devlog.common.security.UserPrincipal;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ActivityLogServiceApi {
 
-    Page<ActivityLog> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Page<ActivityLog> getMyFeedActivities(UserPrincipal currentUser, Pageable pageable);
 }

--- a/src/main/java/org/devlogtwo/devlog/domain/dashboard/controller/DashBoardController.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/dashboard/controller/DashBoardController.java
@@ -51,9 +51,11 @@ public class DashBoardController {
 
     @GetMapping("/api/activities/my")
     public ResponseEntity<GlobalApiResponse<PageResponse<DashboardRecentActivityResponse>>> getRecentActivity(
-            @PageableDefault(size = 10) Pageable pageable) {
+            @PageableDefault(size = 10) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal currentUser) {
 
         PageResponse<DashboardRecentActivityResponse> response = dashBoardService.getRecentActivity(
+                currentUser,
                 pageable);
 
         return ResponseHelper.success(SuccessCode.DASHBOARD_RECENT_ACTIVITY_SUCCESS, response);

--- a/src/main/java/org/devlogtwo/devlog/domain/dashboard/service/DashBoardService.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/dashboard/service/DashBoardService.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.devlogtwo.devlog.common.dto.PageResponse;
+import org.devlogtwo.devlog.common.security.UserPrincipal;
 import org.devlogtwo.devlog.common.type.TaskStatus;
 import org.devlogtwo.devlog.common.util.DescriptionGenerator;
 import org.devlogtwo.devlog.domain.actlog.entity.ActivityLog;
@@ -145,12 +146,14 @@ public class DashBoardService {
     }
 
 
-    public PageResponse<DashboardRecentActivityResponse> getRecentActivity(Pageable pageable) {
+    public PageResponse<DashboardRecentActivityResponse> getRecentActivity(UserPrincipal currentUser,
+                                                                           Pageable pageable) {
 
-        Page<ActivityLog> activityLogPage = activityLogServiceApi.findAllByOrderByCreatedAtDesc(pageable);
+        Page<ActivityLog> activityLogPage = activityLogServiceApi.getMyFeedActivities(currentUser, pageable);
 
         Page<DashboardRecentActivityResponse> responsePage = activityLogPage
-                .map(activityLog -> DashboardRecentActivityResponse.of(activityLog,
+                .map(activityLog -> DashboardRecentActivityResponse.of(
+                        activityLog,
                         descriptionGenerator.createDescription(activityLog)));
 
         return PageResponse.from(responsePage);

--- a/src/main/java/org/devlogtwo/devlog/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/devlogtwo/devlog/domain/user/repository/UserRepository.java
@@ -26,7 +26,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
             nativeQuery = true)
     Integer existsByUsernameIgnoringSoftDelete(@Param("username") String username);
 
-    // ✅ nativeQuery = true를 사용하여 @SQLRestriction을 우회합니다.
+    // nativeQuery = true를 사용하여 @SQLRestriction을 우회합니다.
     @Query(value = """
             SELECT COUNT(*)
             FROM user 


### PR DESCRIPTION
## 📌 관련 이슈
> close #152 

최초에는 권한 상관없이, 전체 유저의 로그를 가져오도록 했습니다.
그 다음에는, 관리자는 모든 유저, 일반 사용자는 일반 사용자의 로그를 모두 가져오도록 수정 중이었습니다.
최종적으로, 권한에 상관 없이 본인의 로그만 가져오는 것이 비즈니스 적으로 맞다고 판단하여 수정했습니다.

<br>

## ✨ 작업 내용
대시보드 -활동 피드에서 본인의 내역만 조회가 가능하도록 수정했습니다.
이와 별개로, 관리자는 활동 로그 조회에서는 전체 유저의 활동 로그를 조회할 수 있습니다.
<br>

## 💬 리뷰 중점사항
<br>

## 📸 스크린샷(선택)
<br>

## 📚 레퍼런스 (선택)
<br>
